### PR TITLE
Improve object comparison speed / distinctWritesOnly

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,8 @@
 {
-	"trailingComma": "es5",
-	"useTabs": false,
-	"tabWidth": 4,
-	"semi": true,
-	"singleQuote": true,
-	"printWidth": 100
+    "trailingComma": "es5",
+    "useTabs": false,
+    "tabWidth": 4,
+    "semi": true,
+    "singleQuote": true,
+    "printWidth": 100
 }

--- a/README.md
+++ b/README.md
@@ -18,30 +18,38 @@ This library excels in the following topics:
 -   Providing a single source of truth for a form. Even linking multiple instances of a form to a single form state is possible.
 -   High test coverage and stability.
 
+<!-- prettier-ignore-start -->
+
 ## Table of Contents
 
--   [Getting Started](#getting-started)
-    _ [Import the NgrxCleanFormsModule](#import-the-ngrxcleanformsmodule)
-    _ [Add the form state to your state managment](#add-the-form-state-to-your-state-managment)
-    _ [Accessing the form state & errors](#accessing-the-form-state-errors)
-    _ [Updating (reducing) the form state](#updating-reducing-the-form-state) \* [Binding your HTML form to your state](#binding-your-html-form-to-your-state)
--   [Additional Resources](#additional-resources)
-    _ [Adding validators](#adding-validators)
-    _ [Using the Angular forms validators](#using-the-angular-forms-validators)
-    _ [Adding custom (state based) validation](#adding-custom-state-based-validation)
-    _ [Displaying errors (CSS classes)](#displaying-errors-css-classes)
-    _ [Displaying errors (values)](#displaying-errors-values)
-    _ [Binding to custom input components](#binding-to-custom-input-components)
-    _ [Binding to an input without a form](#binding-to-an-input-without-a-form)
-    _ [Binding multiple HTML forms to the same state](#binding-multiple-html-forms-to-the-same-state)
-    _ [Disabling forms / Setting disabled](#disabling-forms-setting-disabled)
-    _ [Utilizing FormArrays](#utilizing-formarrays) \* [Additional configuration and throttling](#additional-configuration-and-throttling)
--   [Changelog](#changelog)
-    _ [4.0.0](#400)
-    _ [3.1.0](#310)
--   [Not yet supported features](#not-yet-supported-features)
+* [Getting Started](#getting-started)
+	* [Import the NgrxCleanFormsModule](#import-the-ngrxcleanformsmodule)
+	* [Add the form state to your state managment](#add-the-form-state-to-your-state-managment)
+	* [Accessing the form state & errors](#accessing-the-form-state-errors)
+	* [Updating (reducing) the form state](#updating-reducing-the-form-state)
+	* [Binding your HTML form to your state](#binding-your-html-form-to-your-state)
+* [Additional Resources](#additional-resources)
+	* [Adding validators](#adding-validators)
+	* [Using the Angular forms validators](#using-the-angular-forms-validators)
+	* [Adding custom (state based) validation](#adding-custom-state-based-validation)
+	* [Displaying errors (CSS classes)](#displaying-errors-css-classes)
+	* [Displaying errors (values)](#displaying-errors-values)
+	* [Binding to custom input components](#binding-to-custom-input-components)
+	* [Binding to an input without a form](#binding-to-an-input-without-a-form)
+	* [Binding multiple HTML forms to the same state](#binding-multiple-html-forms-to-the-same-state)
+	* [Disabling forms / Setting disabled](#disabling-forms-setting-disabled)
+	* [Utilizing FormArrays](#utilizing-formarrays)
+	* [Additional configuration and throttling](#additional-configuration-and-throttling)
+* [Changelog](#changelog)
+	* [4.2.0](#420)
+	* [4.1.0](#410)
+	* [4.0.0](#400)
+	* [3.1.0](#310)
+* [Not yet supported features](#not-yet-supported-features)
 
 ## Getting Started
+
+<!-- prettier-ignore-end -->
 
 ```
 npm i ngrx-clean-forms
@@ -389,6 +397,12 @@ The configuration for an individual `FormControl` can also be overridden with th
 ```
 
 ## Changelog
+
+### 4.2.0
+
+**New features:**
+
+-   `distinctWritesOnly` now supports circular objects. Also the comparison performance has greatly increased with the use of [fast-equals](https://www.npmjs.com/package/fast-equals).
 
 ### 4.1.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,12 @@ id: changelog
 title: Changelog
 ---
 
+## 4.2.0
+
+**New features:**
+
+-   `distinctWritesOnly` now supports circular objects. Also the comparison performance has greatly increased with the use of [fast-equals](https://www.npmjs.com/package/fast-equals).
+
 ## 4.1.0
 
 **New features:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8905,6 +8905,11 @@
             "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
             "dev": true
         },
+        "fast-equals": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-2.0.0.tgz",
+            "integrity": "sha512-u6RBd8cSiLLxAiC04wVsLV6GBFDOXcTCgWkd3wEoFXgidPSoAJENqC9m7Jb2vewSvjBIfXV6icKeh3GTKfIaXA=="
+        },
         "fast-glob": {
             "version": "2.2.7",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@angular/router": "~8.2.0",
         "@ngrx/store": "^8.5.2",
         "@ngrx/store-devtools": "^8.5.2",
+        "fast-equals": "^2.0.0",
         "ngrx-clean-forms": "file:dist/ngrx-clean-forms",
         "rxjs": "~6.4.0",
         "tslib": "^1.10.0",

--- a/projects/ngrx-clean-forms/package.json
+++ b/projects/ngrx-clean-forms/package.json
@@ -23,7 +23,7 @@
         "typescript",
         "redux"
     ],
-    "version": "4.1.0",
+    "version": "4.2.0",
     "peerDependencies": {
         "@angular/common": "^8.2.0",
         "@angular/core": "^8.2.0"

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/value-accessor-connector.directive.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/value-accessor-connector.directive.spec.ts
@@ -196,23 +196,33 @@ describe('ValueAccessorConnectorDirective', () => {
             expect(spy).toHaveBeenCalledTimes(1);
         });
 
-        it('duplicate writes with self reference objects should each write', () => {
+        it('duplicate writes with circular referencing objects should write once', () => {
+            const value = 'value';
+
+            function CircularExample(val) {
+                this.me = {
+                    deeply: {
+                        nested: {
+                            reference: this,
+                        },
+                    },
+                    val,
+                };
+            }
+
             const spy = spyOn(testInputComponent, 'writeValue');
 
-            const value: any = {};
-            value.selfReference = value;
-
             testComponent.componentInstance.summary$.next(
-                getFormControlSummary(initFormControl({ value }))
+                getFormControlSummary(initFormControl({ value: new CircularExample(value) }))
             );
             testComponent.detectChanges();
 
             testComponent.componentInstance.summary$.next(
-                getFormControlSummary(initFormControl({ value }))
+                getFormControlSummary(initFormControl({ value: new CircularExample(value) }))
             );
             testComponent.detectChanges();
 
-            expect(spy).toHaveBeenCalledTimes(2);
+            expect(spy).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/value-accessor-connector.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/value-accessor-connector.directive.ts
@@ -3,13 +3,14 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { CONFIG_TOKEN } from '../../config';
 import { FormsConfig } from '../../types';
 import { AbstractControlDirective, CONTROL_DIRECTIVE_SELECTOR } from './abstract-control.directive';
+import { circularDeepEqual } from 'fast-equals';
 
 @Directive({
     selector: `[${CONTROL_DIRECTIVE_SELECTOR}]`,
 })
 export class ValueAccessorConnectorDirective extends AbstractControlDirective<any> {
     accessor: ControlValueAccessor;
-    lastValue: string;
+    lastValue: any;
 
     constructor(
         ref: ElementRef,
@@ -52,14 +53,12 @@ export class ValueAccessorConnectorDirective extends AbstractControlDirective<an
     }
 
     equalsLastValue(value: any) {
-        try {
-            const valueString = JSON.stringify(value);
-            const isEqual = valueString === this.lastValue;
+        const result = circularDeepEqual(value, this.lastValue);
 
-            this.lastValue = valueString;
-            return isEqual;
-        } catch {
-            return false;
+        if (!result) {
+            this.lastValue = value;
         }
+
+        return result;
     }
 }

--- a/projects/ngrx-clean-forms/src/lib/types.ts
+++ b/projects/ngrx-clean-forms/src/lib/types.ts
@@ -15,7 +15,8 @@ export interface FormsConfig {
     throttleTime: number;
     /**
      * Specifies whether only distinct values should be written to a `FormControl`.
-     * Only applies to custom inputs added with `ControlValueAccessor`. Prevents update loops and uses `JSON.stringfy()` for comparison.
+     * Only applies to custom inputs added with `ControlValueAccessor`.
+     * Prevents update loops and uses [fast-equals](https://www.npmjs.com/package/fast-equals) for comparison.
      */
     distinctWritesOnly: boolean;
 }


### PR DESCRIPTION
Immproved the object comparison speed by including [fast-equals](https://www.npmjs.com/package/fast-equals#benchmarks) circular equality check.