### PR TITLE
Add changed & css classes to control, group & array

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This library excels in the following topics:
 	* [Utilizing FormArrays](#utilizing-formarrays)
 	* [Additional configuration and throttling](#additional-configuration-and-throttling)
 * [Changelog](#changelog)
+* [4.3.0](#430)
 	* [4.2.0](#420)
 	* [4.1.0](#410)
 	* [4.0.0](#400)
@@ -261,7 +262,7 @@ This variant of validation should only be used, when the `validators` array isn'
 
 ### Displaying errors (CSS classes)
 
-This library utilizes the same error classes as angular. Excerpt from the Angular [documentation](https://angular.io/guide/form-validation#control-status-css-classes):
+This library extends the error classes of Angular. Excerpt from the Angular [documentation](https://angular.io/guide/form-validation#control-status-css-classes):
 
 -   `.ng-valid`
 -   `.ng-invalid`
@@ -270,6 +271,11 @@ This library utilizes the same error classes as angular. Excerpt from the Angula
 -   `.ng-dirty`
 -   `.ng-untouched`
 -   `.ng-touched`
+
+Added classes:
+
+-   `ng-changed`: Value changed from the initial value.
+-   `ng-initial`: Value is the same as the initial value.
 
 Those classes will be automatically assigned to the controls and forms managed by this library.
 
@@ -397,6 +403,16 @@ The configuration for an individual `FormControl` can also be overridden with th
 ```
 
 ## Changelog
+
+## 4.3.0
+
+**New features:**
+
+-   Every `FormControlState` now supports the `initialValue` property. It is set automatically when creating with one of the provided initializer functions.
+-   Every `FormControlSummary` now additional supports the `changed` property. It is set to true when `initialValue` and `value` are different. For object comparison again [fast-equals](https://www.npmjs.com/package/fast-equals) was used.
+    -   CSS class `.ng-changed` is now set on inputs when `changed: true`.
+    -   CSS class `.ng-initial` is now set on inputs when `changed: false`.
+-   `FormGroupSummary` and `FormGroupArray` also support the `changed` property. It is set when atleast one control was changed.
 
 ### 4.2.0
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,16 @@ id: changelog
 title: Changelog
 ---
 
+## 4.3.0
+
+**New features:**
+
+-   Every `FormControlState` now supports the `initialValue` property. It is set automatically when creating with one of the provided initializer functions.
+-   Every `FormControlSummary` now additional supports the `changed` property. It is set to true when `initialValue` and `value` are different. For object comparison again [fast-equals](https://www.npmjs.com/package/fast-equals) was used.
+    -   CSS class `.ng-changed` is now set on inputs when `changed: true`.
+    -   CSS class `.ng-initial` is now set on inputs when `changed: false`.
+-   `FormGroupSummary` and `FormGroupArray` also support the `changed` property. It is set when atleast one control was changed.
+
 ## 4.2.0
 
 **New features:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -331,29 +331,25 @@
                     "dependencies": {
                         "abbrev": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-                            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "are-we-there-yet": {
                             "version": "1.1.5",
-                            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-                            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -363,15 +359,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
-                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-                            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -381,43 +375,37 @@
                         },
                         "chownr": {
                             "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-                            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "debug": {
                             "version": "3.2.6",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -426,29 +414,25 @@
                         },
                         "deep-extend": {
                             "version": "0.6.0",
-                            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-                            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "delegates": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "detect-libc": {
                             "version": "1.0.3",
-                            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-                            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "fs-minipass": {
                             "version": "1.2.7",
-                            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-                            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -457,15 +441,13 @@
                         },
                         "fs.realpath": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "gauge": {
                             "version": "2.7.4",
-                            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -481,8 +463,7 @@
                         },
                         "glob": {
                             "version": "7.1.6",
-                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-                            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -496,15 +477,13 @@
                         },
                         "has-unicode": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "iconv-lite": {
                             "version": "0.4.24",
-                            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -513,8 +492,7 @@
                         },
                         "ignore-walk": {
                             "version": "3.0.3",
-                            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-                            "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -523,8 +501,7 @@
                         },
                         "inflight": {
                             "version": "1.0.6",
-                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -534,22 +511,19 @@
                         },
                         "inherits": {
                             "version": "2.0.4",
-                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
-                            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-                            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -558,15 +532,13 @@
                         },
                         "isarray": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "minimatch": {
                             "version": "3.0.4",
-                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -575,15 +547,13 @@
                         },
                         "minimist": {
                             "version": "0.0.8",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "minipass": {
                             "version": "2.9.0",
-                            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -593,8 +563,7 @@
                         },
                         "minizlib": {
                             "version": "1.3.3",
-                            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-                            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -603,8 +572,7 @@
                         },
                         "mkdirp": {
                             "version": "0.5.1",
-                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -613,15 +581,13 @@
                         },
                         "ms": {
                             "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "needle": {
                             "version": "2.4.0",
-                            "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-                            "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -632,8 +598,7 @@
                         },
                         "node-pre-gyp": {
                             "version": "0.14.0",
-                            "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-                            "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -651,8 +616,7 @@
                         },
                         "nopt": {
                             "version": "4.0.1",
-                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-                            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -662,8 +626,7 @@
                         },
                         "npm-bundled": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-                            "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -672,15 +635,13 @@
                         },
                         "npm-normalize-package-bin": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-                            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "npm-packlist": {
                             "version": "1.4.7",
-                            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
-                            "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -690,8 +651,7 @@
                         },
                         "npmlog": {
                             "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-                            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -703,22 +663,19 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "once": {
                             "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -727,22 +684,19 @@
                         },
                         "os-homedir": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "os-tmpdir": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "osenv": {
                             "version": "0.1.5",
-                            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-                            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -752,22 +706,19 @@
                         },
                         "path-is-absolute": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "process-nextick-args": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-                            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "rc": {
                             "version": "1.2.8",
-                            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-                            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -779,8 +730,7 @@
                             "dependencies": {
                                 "minimist": {
                                     "version": "1.2.0",
-                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                                    "bundled": true,
                                     "dev": true,
                                     "optional": true
                                 }
@@ -788,8 +738,7 @@
                         },
                         "readable-stream": {
                             "version": "2.3.6",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -804,8 +753,7 @@
                         },
                         "rimraf": {
                             "version": "2.7.1",
-                            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -814,50 +762,43 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-                            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "sax": {
                             "version": "1.2.4",
-                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-                            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "semver": {
                             "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "set-blocking": {
                             "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "signal-exit": {
                             "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -868,8 +809,7 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -878,8 +818,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -888,15 +827,13 @@
                         },
                         "strip-json-comments": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "tar": {
                             "version": "4.4.13",
-                            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-                            "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -911,15 +848,13 @@
                         },
                         "util-deprecate": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "wide-align": {
                             "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-                            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -928,15 +863,13 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "yallist": {
                             "version": "3.1.1",
-                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         }
@@ -1106,12 +1039,12 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-            "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "^7.8.3"
             }
         },
         "@babel/compat-data": {
@@ -1137,33 +1070,10 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001025",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-                    "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
+                    "version": "1.0.30001027",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+                    "integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
                     "dev": true
-                },
-                "electron-to-chromium": {
-                    "version": "1.3.345",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-                    "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
-                    "dev": true
-                },
-                "node-releases": {
-                    "version": "1.1.48",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
-                    "integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^6.3.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                            "dev": true
-                        }
-                    }
                 },
                 "semver": {
                     "version": "5.7.1",
@@ -1196,112 +1106,6 @@
                 "source-map": "^0.5.0"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-                    "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-                    "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.4",
-                        "@babel/helper-function-name": "^7.8.3",
-                        "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.4",
-                        "@babel/types": "^7.8.3",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1310,24 +1114,6 @@
                     "requires": {
                         "ms": "^2.1.1"
                     }
-                },
-                "globals": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
                 },
                 "json5": {
                     "version": "2.1.1",
@@ -1355,22 +1141,16 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
                     "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
                     "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
                 }
             }
         },
         "@babel/generator": {
-            "version": "7.7.7",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
-            "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+            "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4",
+                "@babel/types": "^7.8.3",
                 "jsesc": "^2.5.1",
                 "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
@@ -1397,25 +1177,6 @@
             "dev": true,
             "requires": {
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -1426,25 +1187,6 @@
             "requires": {
                 "@babel/helper-explode-assignable-expression": "^7.8.3",
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-builder-react-jsx": {
@@ -1455,25 +1197,6 @@
             "requires": {
                 "@babel/types": "^7.8.3",
                 "esutils": "^2.0.0"
-            },
-            "dependencies": {
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-call-delegate": {
@@ -1485,159 +1208,6 @@
                 "@babel/helper-hoist-variables": "^7.8.3",
                 "@babel/traverse": "^7.8.3",
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-                    "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-                    "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.4",
-                        "@babel/helper-function-name": "^7.8.3",
-                        "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.4",
-                        "@babel/types": "^7.8.3",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-compilation-targets": {
@@ -1665,33 +1235,10 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001025",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-                    "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
+                    "version": "1.0.30001027",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+                    "integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
                     "dev": true
-                },
-                "electron-to-chromium": {
-                    "version": "1.3.345",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-                    "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
-                    "dev": true
-                },
-                "node-releases": {
-                    "version": "1.1.48",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
-                    "integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^6.3.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                            "dev": true
-                        }
-                    }
                 },
                 "semver": {
                     "version": "5.7.1",
@@ -1713,97 +1260,6 @@
                 "@babel/helper-plugin-utils": "^7.8.3",
                 "@babel/helper-replace-supers": "^7.8.3",
                 "@babel/helper-split-export-declaration": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
@@ -1862,88 +1318,6 @@
                 "@babel/helper-function-name": "^7.8.3",
                 "@babel/types": "^7.8.3",
                 "lodash": "^4.17.13"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-explode-assignable-expression": {
@@ -1954,179 +1328,26 @@
             "requires": {
                 "@babel/traverse": "^7.8.3",
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-                    "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-                    "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.4",
-                        "@babel/helper-function-name": "^7.8.3",
-                        "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.4",
-                        "@babel/types": "^7.8.3",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-            "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+            "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.7.4",
-                "@babel/template": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/helper-get-function-arity": "^7.8.3",
+                "@babel/template": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-            "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+            "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-hoist-variables": {
@@ -2136,25 +1357,6 @@
             "dev": true,
             "requires": {
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-member-expression-to-functions": {
@@ -2164,25 +1366,6 @@
             "dev": true,
             "requires": {
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-module-imports": {
@@ -2192,25 +1375,6 @@
             "dev": true,
             "requires": {
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-module-transforms": {
@@ -2225,77 +1389,6 @@
                 "@babel/template": "^7.8.3",
                 "@babel/types": "^7.8.3",
                 "lodash": "^4.17.13"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -2305,25 +1398,6 @@
             "dev": true,
             "requires": {
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-plugin-utils": {
@@ -2352,159 +1426,6 @@
                 "@babel/template": "^7.8.3",
                 "@babel/traverse": "^7.8.3",
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-                    "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-                    "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.4",
-                        "@babel/helper-function-name": "^7.8.3",
-                        "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.4",
-                        "@babel/types": "^7.8.3",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-replace-supers": {
@@ -2517,159 +1438,6 @@
                 "@babel/helper-optimise-call-expression": "^7.8.3",
                 "@babel/traverse": "^7.8.3",
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-                    "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-                    "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.4",
-                        "@babel/helper-function-name": "^7.8.3",
-                        "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.4",
-                        "@babel/types": "^7.8.3",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-simple-access": {
@@ -2680,77 +1448,15 @@
             "requires": {
                 "@babel/template": "^7.8.3",
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-            "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+            "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.7.4"
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/helper-wrap-function": {
@@ -2763,159 +1469,6 @@
                 "@babel/template": "^7.8.3",
                 "@babel/traverse": "^7.8.3",
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-                    "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-                    "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.4",
-                        "@babel/helper-function-name": "^7.8.3",
-                        "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.4",
-                        "@babel/types": "^7.8.3",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/helpers": {
@@ -2927,165 +1480,12 @@
                 "@babel/template": "^7.8.3",
                 "@babel/traverse": "^7.8.4",
                 "@babel/types": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/generator": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-                    "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.13",
-                        "source-map": "^0.5.0"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-                    "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/generator": "^7.8.4",
-                        "@babel/helper-function-name": "^7.8.3",
-                        "@babel/helper-split-export-declaration": "^7.8.3",
-                        "@babel/parser": "^7.8.4",
-                        "@babel/types": "^7.8.3",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.13"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-                    "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/highlight": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-            "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+            "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
@@ -3102,9 +1502,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.7.7",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
-            "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+            "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
             "dev": true
         },
         "@babel/plugin-proposal-async-generator-functions": {
@@ -3334,99 +1734,10 @@
                 "globals": "^11.1.0"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-split-export-declaration": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-                    "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
                 "globals": {
                     "version": "11.12.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
                     "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-                    "dev": true
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
                     "dev": true
                 }
             }
@@ -3495,88 +1806,6 @@
             "requires": {
                 "@babel/helper-function-name": "^7.8.3",
                 "@babel/helper-plugin-utils": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-                    "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.8.3"
-                    }
-                },
-                "@babel/helper-function-name": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-                    "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-get-function-arity": "^7.8.3",
-                        "@babel/template": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/highlight": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-                    "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.0.0",
-                        "esutils": "^2.0.2",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.8.4",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-                    "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-                    "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.8.3",
-                        "@babel/parser": "^7.8.3",
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/plugin-transform-literals": {
@@ -3679,34 +1908,6 @@
                 "@babel/helper-call-delegate": "^7.8.3",
                 "@babel/helper-get-function-arity": "^7.8.3",
                 "@babel/helper-plugin-utils": "^7.8.3"
-            },
-            "dependencies": {
-                "@babel/helper-get-function-arity": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-                    "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.8.3"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@babel/plugin-transform-property-literals": {
@@ -3922,17 +2123,6 @@
                 "semver": "^5.5.0"
             },
             "dependencies": {
-                "@babel/types": {
-                    "version": "7.8.3",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-                    "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.13",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
                 "browserslist": {
                     "version": "4.8.6",
                     "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.6.tgz",
@@ -3945,44 +2135,15 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001025",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-                    "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
+                    "version": "1.0.30001027",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+                    "integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
                     "dev": true
-                },
-                "electron-to-chromium": {
-                    "version": "1.3.345",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-                    "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
-                    "dev": true
-                },
-                "node-releases": {
-                    "version": "1.1.48",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
-                    "integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^6.3.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                            "dev": true
-                        }
-                    }
                 },
                 "semver": {
                     "version": "5.7.1",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-                    "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
                     "dev": true
                 }
             }
@@ -4032,28 +2193,28 @@
             }
         },
         "@babel/template": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-            "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+            "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.7.4",
-                "@babel/types": "^7.7.4"
+                "@babel/code-frame": "^7.8.3",
+                "@babel/parser": "^7.8.3",
+                "@babel/types": "^7.8.3"
             }
         },
         "@babel/traverse": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-            "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+            "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.5.5",
-                "@babel/generator": "^7.7.4",
-                "@babel/helper-function-name": "^7.7.4",
-                "@babel/helper-split-export-declaration": "^7.7.4",
-                "@babel/parser": "^7.7.4",
-                "@babel/types": "^7.7.4",
+                "@babel/code-frame": "^7.8.3",
+                "@babel/generator": "^7.8.4",
+                "@babel/helper-function-name": "^7.8.3",
+                "@babel/helper-split-export-declaration": "^7.8.3",
+                "@babel/parser": "^7.8.4",
+                "@babel/types": "^7.8.3",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.13"
@@ -4083,9 +2244,9 @@
             }
         },
         "@babel/types": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-            "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+            "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
@@ -4167,9 +2328,9 @@
             }
         },
         "@sindresorhus/is": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-            "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+            "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
             "dev": true
         },
         "@szmarczak/http-timer": {
@@ -4264,9 +2425,9 @@
             "dev": true
         },
         "@types/q": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
-            "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+            "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
             "dev": true
         },
         "@types/resolve": {
@@ -4291,9 +2452,9 @@
             "dev": true
         },
         "@types/webpack-sources": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.5.tgz",
-            "integrity": "sha512-zfvjpp7jiafSmrzJ2/i3LqOyTYTuJ7u1KOXlKgDlvsj9Rr0x7ZiYu5lZbXwobL7lmsRNtPXlBfmaUD8eU2Hu8w==",
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.6.tgz",
+            "integrity": "sha512-FtAWR7wR5ocJ9+nP137DV81tveD/ZgB1sadnJ/axUGM3BUVfRPx8oQNMtv3JNfTeHx3VP7cXiyfR/jmtEsVHsQ==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -4536,9 +2697,9 @@
             "dev": true
         },
         "adm-zip": {
-            "version": "0.4.13",
-            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.13.tgz",
-            "integrity": "sha512-fERNJX8sOXfel6qCBCMPvZLzENBEhZTzKqg6vrOW5pvoEaQuJhRU4ndTAh6lHOxn1I6jnz2NHra56ZODM751uw==",
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
+            "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g==",
             "dev": true
         },
         "after": {
@@ -4957,9 +3118,9 @@
             "dev": true
         },
         "aws4": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-            "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
             "dev": true
         },
         "axobject-query": {
@@ -5398,35 +3559,6 @@
                 "pify": "^4.0.1"
             },
             "dependencies": {
-                "@sindresorhus/is": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-                    "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
-                    "dev": true
-                },
-                "cacheable-request": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-                    "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-                    "dev": true,
-                    "requires": {
-                        "clone-response": "1.0.2",
-                        "get-stream": "3.0.0",
-                        "http-cache-semantics": "3.8.1",
-                        "keyv": "3.0.0",
-                        "lowercase-keys": "1.0.0",
-                        "normalize-url": "2.0.1",
-                        "responselike": "1.0.2"
-                    },
-                    "dependencies": {
-                        "lowercase-keys": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-                            "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-                            "dev": true
-                        }
-                    }
-                },
                 "download": {
                     "version": "7.1.0",
                     "resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
@@ -5500,21 +3632,6 @@
                         }
                     }
                 },
-                "import-lazy": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
-                    "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
-                    "dev": true
-                },
-                "keyv": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-                    "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-                    "dev": true,
-                    "requires": {
-                        "json-buffer": "3.0.0"
-                    }
-                },
                 "make-dir": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -5530,17 +3647,6 @@
                             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                             "dev": true
                         }
-                    }
-                },
-                "normalize-url": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-                    "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-                    "dev": true,
-                    "requires": {
-                        "prepend-http": "^2.0.0",
-                        "query-string": "^5.0.1",
-                        "sort-keys": "^2.0.0"
                     }
                 },
                 "p-cancelable": {
@@ -5573,24 +3679,13 @@
                     "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
                     "dev": true
                 },
-                "query-string": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-                    "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+                "url-parse-lax": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+                    "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
                     "dev": true,
                     "requires": {
-                        "decode-uri-component": "^0.2.0",
-                        "object-assign": "^4.1.0",
-                        "strict-uri-encode": "^1.0.0"
-                    }
-                },
-                "sort-keys": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-                    "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-                    "dev": true,
-                    "requires": {
-                        "is-plain-obj": "^1.0.0"
+                        "prepend-http": "^2.0.0"
                     }
                 }
             }
@@ -6023,46 +4118,68 @@
             }
         },
         "cacheable-request": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
-            "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+            "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
             "dev": true,
             "requires": {
-                "clone-response": "^1.0.2",
-                "get-stream": "^5.1.0",
-                "http-cache-semantics": "^4.0.0",
-                "keyv": "^3.0.0",
-                "lowercase-keys": "^2.0.0",
-                "normalize-url": "^4.1.0",
-                "responselike": "^1.0.2"
+                "clone-response": "1.0.2",
+                "get-stream": "3.0.0",
+                "http-cache-semantics": "3.8.1",
+                "keyv": "3.0.0",
+                "lowercase-keys": "1.0.0",
+                "normalize-url": "2.0.1",
+                "responselike": "1.0.2"
             },
             "dependencies": {
                 "get-stream": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-                    "dev": true,
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                },
-                "http-cache-semantics": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-                    "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                     "dev": true
                 },
                 "lowercase-keys": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-                    "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                    "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
                     "dev": true
                 },
                 "normalize-url": {
-                    "version": "4.5.0",
-                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-                    "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+                    "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "^2.0.0",
+                        "query-string": "^5.0.1",
+                        "sort-keys": "^2.0.0"
+                    }
+                },
+                "prepend-http": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
                     "dev": true
+                },
+                "query-string": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+                    "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+                    "dev": true,
+                    "requires": {
+                        "decode-uri-component": "^0.2.0",
+                        "object-assign": "^4.1.0",
+                        "strict-uri-encode": "^1.0.0"
+                    }
+                },
+                "sort-keys": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+                    "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-obj": "^1.0.0"
+                    }
                 }
             }
         },
@@ -6468,14 +4585,6 @@
                 "@types/q": "^1.5.1",
                 "chalk": "^2.4.1",
                 "q": "^1.1.2"
-            },
-            "dependencies": {
-                "@types/q": {
-                    "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
-                    "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
-                    "dev": true
-                }
             }
         },
         "code-point-at": {
@@ -6889,33 +4998,10 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001025",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-                    "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
+                    "version": "1.0.30001027",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+                    "integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
                     "dev": true
-                },
-                "electron-to-chromium": {
-                    "version": "1.3.345",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-                    "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
-                    "dev": true
-                },
-                "node-releases": {
-                    "version": "1.1.48",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
-                    "integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^6.3.0"
-                    },
-                    "dependencies": {
-                        "semver": {
-                            "version": "6.3.0",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-                            "dev": true
-                        }
-                    }
                 },
                 "semver": {
                     "version": "7.0.0",
@@ -7012,12 +5098,6 @@
                 "yargs": "^2.3.0"
             },
             "dependencies": {
-                "wordwrap": {
-                    "version": "0.0.2",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                    "dev": true
-                },
                 "yargs": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-2.3.0.tgz",
@@ -7264,9 +5344,9 @@
             "dev": true
         },
         "damerau-levenshtein": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
-            "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
+            "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
             "dev": true
         },
         "dashdash": {
@@ -7499,12 +5579,20 @@
             "dev": true,
             "requires": {
                 "strip-bom": "^3.0.0"
+            },
+            "dependencies": {
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                }
             }
         },
         "defer-to-connect": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.1.tgz",
-            "integrity": "sha512-J7thop4u3mRTkYRQ+Vpfwy2G5Ehoy82I14+14W4YMDLKdWloI9gSzRbV30s/NckQGVJtPkWNcW4oMAUigTdqiQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+            "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
             "dev": true
         },
         "define-properties": {
@@ -7834,9 +5922,9 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001025",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-                    "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
+                    "version": "1.0.30001027",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+                    "integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
                     "dev": true
                 },
                 "chalk": {
@@ -7897,28 +5985,11 @@
                     "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
                     "dev": true
                 },
-                "electron-to-chromium": {
-                    "version": "1.3.345",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.345.tgz",
-                    "integrity": "sha512-f8nx53+Z9Y+SPWGg3YdHrbYYfIJAtbUjpFfW4X1RwTZ94iUG7geg9tV8HqzAXX7XTNgyWgAFvce4yce8ZKxKmg==",
-                    "dev": true
-                },
                 "escape-string-regexp": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
                     "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
                     "dev": true
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
                 },
                 "glob": {
                     "version": "7.1.6",
@@ -7932,15 +6003,6 @@
                         "minimatch": "^3.0.4",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "node-releases": {
-                    "version": "1.1.48",
-                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.48.tgz",
-                    "integrity": "sha512-Hr8BbmUl1ujAST0K0snItzEA5zkJTQup8VNTKNfT6Zw8vTJkIiagUPNfxHmgDOyfFYNfKAul40sD0UEYTvwebw==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^6.3.0"
                     }
                 },
                 "postcss": {
@@ -8102,28 +6164,6 @@
                     "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                     "dev": true
                 },
-                "got": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-                    "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-                    "dev": true,
-                    "requires": {
-                        "decompress-response": "^3.2.0",
-                        "duplexer3": "^0.1.4",
-                        "get-stream": "^3.0.0",
-                        "is-plain-obj": "^1.1.0",
-                        "is-retry-allowed": "^1.0.0",
-                        "is-stream": "^1.0.0",
-                        "isurl": "^1.0.0-alpha5",
-                        "lowercase-keys": "^1.0.0",
-                        "p-cancelable": "^0.3.0",
-                        "p-timeout": "^1.1.1",
-                        "safe-buffer": "^5.0.1",
-                        "timed-out": "^4.0.0",
-                        "url-parse-lax": "^1.0.0",
-                        "url-to-options": "^1.0.1"
-                    }
-                },
                 "make-dir": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -8133,26 +6173,11 @@
                         "pify": "^3.0.0"
                     }
                 },
-                "p-cancelable": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-                    "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-                    "dev": true
-                },
                 "pify": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
-                },
-                "url-parse-lax": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-                    "dev": true,
-                    "requires": {
-                        "prepend-http": "^1.0.1"
-                    }
                 }
             }
         },
@@ -8197,9 +6222,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.331",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.331.tgz",
-            "integrity": "sha512-GuDv5gkxwRROYnmIVFUohoyrNapWCKLNn80L7Pa+9WRF/oY4t7XLH7wBMsYBgIRwi8BvEvsGKLKh8kOciOp6kA==",
+            "version": "1.3.348",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.348.tgz",
+            "integrity": "sha512-6O0IInybavGdYtcbI4ryF/9e3Qi8/soi6C68ELRseJuTwQPKq39uGgVVeQHG28t69Sgsky09nXBRhUiFXsZyFQ==",
             "dev": true
         },
         "elliptic": {
@@ -8390,9 +6415,9 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
-            "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+            "version": "1.17.4",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+            "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.1",
@@ -8989,9 +7014,9 @@
             },
             "dependencies": {
                 "schema-utils": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
-                    "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
+                    "version": "2.6.4",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+                    "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
                     "dev": true,
                     "requires": {
                         "ajv": "^6.10.2",
@@ -9122,9 +7147,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
-            "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
+            "integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
             "dev": true,
             "requires": {
                 "debug": "^3.0.0"
@@ -9942,12 +7967,12 @@
             "dev": true
         },
         "fs-extra": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
+                "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
                 "universalify": "^0.1.0"
             }
@@ -10207,22 +8232,33 @@
             }
         },
         "got": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-            "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+            "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
             "dev": true,
             "requires": {
-                "@sindresorhus/is": "^0.14.0",
-                "@szmarczak/http-timer": "^1.1.2",
-                "cacheable-request": "^6.0.0",
-                "decompress-response": "^3.3.0",
+                "decompress-response": "^3.2.0",
                 "duplexer3": "^0.1.4",
-                "get-stream": "^4.1.0",
-                "lowercase-keys": "^1.0.1",
-                "mimic-response": "^1.0.1",
-                "p-cancelable": "^1.0.0",
-                "to-readable-stream": "^1.0.0",
-                "url-parse-lax": "^3.0.0"
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+                    "dev": true
+                }
             }
         },
         "graceful-fs": {
@@ -10287,26 +8323,6 @@
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
             "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
             "dev": true
-        },
-        "handlebars": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.0.tgz",
-            "integrity": "sha512-PaZ6G6nYzfJ0Hd1WIhOpsnUPWh1R0Pg//r4wEYOtzG65c2V8RJQ/++yYlVmuoQ7EMXcb4eri5+FB2XH1Lwed9g==",
-            "dev": true,
-            "requires": {
-                "neo-async": "^2.6.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
         },
         "har-schema": {
             "version": "2.0.0",
@@ -10533,6 +8549,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
             "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+            "dev": true
+        },
+        "html-escaper": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+            "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
             "dev": true
         },
         "htmlparser2": {
@@ -10897,9 +8919,9 @@
             }
         },
         "import-lazy": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-            "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-3.1.0.tgz",
+            "integrity": "sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==",
             "dev": true
         },
         "import-local": {
@@ -11224,13 +9246,10 @@
             "dev": true
         },
         "is-finite": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-            "dev": true,
-            "requires": {
-                "number-is-nan": "^1.0.0"
-            }
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+            "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+            "dev": true
         },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
@@ -11718,12 +9737,12 @@
             }
         },
         "istanbul-reports": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-            "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+            "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.1.2"
+                "html-escaper": "^2.0.0"
             }
         },
         "isurl": {
@@ -12057,29 +10076,25 @@
                     "dependencies": {
                         "abbrev": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-                            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "are-we-there-yet": {
                             "version": "1.1.5",
-                            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-                            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12089,15 +10104,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
-                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-                            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12107,43 +10120,37 @@
                         },
                         "chownr": {
                             "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-                            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "debug": {
                             "version": "3.2.6",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12152,29 +10159,25 @@
                         },
                         "deep-extend": {
                             "version": "0.6.0",
-                            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-                            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "delegates": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "detect-libc": {
                             "version": "1.0.3",
-                            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-                            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "fs-minipass": {
                             "version": "1.2.7",
-                            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-                            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12183,15 +10186,13 @@
                         },
                         "fs.realpath": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "gauge": {
                             "version": "2.7.4",
-                            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12207,8 +10208,7 @@
                         },
                         "glob": {
                             "version": "7.1.6",
-                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-                            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12222,15 +10222,13 @@
                         },
                         "has-unicode": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "iconv-lite": {
                             "version": "0.4.24",
-                            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12239,8 +10237,7 @@
                         },
                         "ignore-walk": {
                             "version": "3.0.3",
-                            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-                            "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12249,8 +10246,7 @@
                         },
                         "inflight": {
                             "version": "1.0.6",
-                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12260,22 +10256,19 @@
                         },
                         "inherits": {
                             "version": "2.0.4",
-                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
-                            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-                            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12284,15 +10277,13 @@
                         },
                         "isarray": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "minimatch": {
                             "version": "3.0.4",
-                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12301,15 +10292,13 @@
                         },
                         "minimist": {
                             "version": "0.0.8",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "minipass": {
                             "version": "2.9.0",
-                            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12319,8 +10308,7 @@
                         },
                         "minizlib": {
                             "version": "1.3.3",
-                            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-                            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12329,8 +10317,7 @@
                         },
                         "mkdirp": {
                             "version": "0.5.1",
-                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12339,15 +10326,13 @@
                         },
                         "ms": {
                             "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "needle": {
                             "version": "2.4.0",
-                            "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-                            "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12358,8 +10343,7 @@
                         },
                         "node-pre-gyp": {
                             "version": "0.14.0",
-                            "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-                            "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12377,8 +10361,7 @@
                         },
                         "nopt": {
                             "version": "4.0.1",
-                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-                            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12388,8 +10371,7 @@
                         },
                         "npm-bundled": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-                            "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12398,15 +10380,13 @@
                         },
                         "npm-normalize-package-bin": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-                            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "npm-packlist": {
                             "version": "1.4.7",
-                            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
-                            "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12416,8 +10396,7 @@
                         },
                         "npmlog": {
                             "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-                            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12429,22 +10408,19 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "once": {
                             "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12453,22 +10429,19 @@
                         },
                         "os-homedir": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "os-tmpdir": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "osenv": {
                             "version": "0.1.5",
-                            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-                            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12478,22 +10451,19 @@
                         },
                         "path-is-absolute": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "process-nextick-args": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-                            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "rc": {
                             "version": "1.2.8",
-                            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-                            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12505,8 +10475,7 @@
                             "dependencies": {
                                 "minimist": {
                                     "version": "1.2.0",
-                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                                    "bundled": true,
                                     "dev": true,
                                     "optional": true
                                 }
@@ -12514,8 +10483,7 @@
                         },
                         "readable-stream": {
                             "version": "2.3.6",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12530,8 +10498,7 @@
                         },
                         "rimraf": {
                             "version": "2.7.1",
-                            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12540,50 +10507,43 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-                            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "sax": {
                             "version": "1.2.4",
-                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-                            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "semver": {
                             "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "set-blocking": {
                             "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "signal-exit": {
                             "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12594,8 +10554,7 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12604,8 +10563,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12614,15 +10572,13 @@
                         },
                         "strip-json-comments": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "tar": {
                             "version": "4.4.13",
-                            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-                            "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12637,15 +10593,13 @@
                         },
                         "util-deprecate": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "wide-align": {
                             "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-                            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -12654,15 +10608,13 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "yallist": {
                             "version": "3.1.1",
-                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         }
@@ -12760,9 +10712,9 @@
             }
         },
         "karma-jasmine-html-reporter": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.5.1.tgz",
-            "integrity": "sha512-LlLqsoGyxT1981z46BRaC1SaY4pTo4EHCA/qZvJEMQXzTtGMyIlmwtxny6FiLO/N/OmZh69eaoNzvBkbHVVFQA==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-1.5.2.tgz",
+            "integrity": "sha512-ILBPsXqQ3eomq+oaQsM311/jxsypw5/d0LnZXj26XkfThwq7jZ55A2CFSKJVA5VekbbOGvMyv7d3juZj0SeTxA==",
             "dev": true
         },
         "karma-source-map-support": {
@@ -12775,9 +10727,9 @@
             }
         },
         "keyv": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
-            "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+            "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
             "dev": true,
             "requires": {
                 "json-buffer": "3.0.0"
@@ -12790,9 +10742,9 @@
             "dev": true
         },
         "kind-of": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
         "latest-version": {
@@ -13000,15 +10952,6 @@
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "^0.2.0"
-                    }
                 }
             }
         },
@@ -13237,9 +11180,9 @@
             }
         },
         "loglevel": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
-            "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+            "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
             "dev": true
         },
         "longest": {
@@ -13511,65 +11454,6 @@
                 "read-pkg-up": "^1.0.1",
                 "redent": "^1.0.0",
                 "trim-newlines": "^1.0.0"
-            },
-            "dependencies": {
-                "find-up": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                    "dev": true,
-                    "requires": {
-                        "path-exists": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true,
-                    "requires": {
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "path-type": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "pify": "^2.0.0",
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
-                },
-                "read-pkg": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
-                    }
-                }
             }
         },
         "merge-descriptors": {
@@ -13997,32 +11881,49 @@
                     "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
                     "dev": true
                 },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                "parse-json": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+                    "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
+                    "integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^5.0.0"
                     }
                 },
                 "rimraf": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-                    "integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
                     "dev": true,
                     "requires": {
                         "glob": "^7.1.3"
                     }
                 }
-            }
-        },
-        "ngrx-clean-forms": {
-            "version": "file:dist/ngrx-clean-forms",
-            "requires": {
-                "tslib": "^1.9.0"
             }
         },
         "nice-try": {
@@ -14100,9 +12001,9 @@
             "dev": true
         },
         "node-releases": {
-            "version": "1.1.45",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.45.tgz",
-            "integrity": "sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==",
+            "version": "1.1.49",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.49.tgz",
+            "integrity": "sha512-xH8t0LS0disN0mtRCh+eByxFPie+msJUBL/lJDBuap53QGiYPa9joh83K4pCZgWJ+2L4b9h88vCVdXQ60NO2bg==",
             "dev": true,
             "requires": {
                 "semver": "^6.3.0"
@@ -14215,13 +12116,14 @@
             }
         },
         "npm-packlist": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
-            "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+            "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
             "dev": true,
             "requires": {
                 "ignore-walk": "^3.0.1",
-                "npm-bundled": "^1.0.1"
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
             }
         },
         "npm-pick-manifest": {
@@ -14573,9 +12475,9 @@
             }
         },
         "p-cancelable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-            "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+            "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
             "dev": true
         },
         "p-defer": {
@@ -14684,6 +12586,98 @@
                 "registry-auth-token": "^4.0.0",
                 "registry-url": "^5.0.0",
                 "semver": "^6.2.0"
+            },
+            "dependencies": {
+                "@sindresorhus/is": {
+                    "version": "0.14.0",
+                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
+                    "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
+                    "dev": true
+                },
+                "cacheable-request": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+                    "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
+                    "dev": true,
+                    "requires": {
+                        "clone-response": "^1.0.2",
+                        "get-stream": "^5.1.0",
+                        "http-cache-semantics": "^4.0.0",
+                        "keyv": "^3.0.0",
+                        "lowercase-keys": "^2.0.0",
+                        "normalize-url": "^4.1.0",
+                        "responselike": "^1.0.2"
+                    },
+                    "dependencies": {
+                        "get-stream": {
+                            "version": "5.1.0",
+                            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+                            "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                            "dev": true,
+                            "requires": {
+                                "pump": "^3.0.0"
+                            }
+                        },
+                        "lowercase-keys": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+                            "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "got": {
+                    "version": "9.6.0",
+                    "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
+                    "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
+                    "dev": true,
+                    "requires": {
+                        "@sindresorhus/is": "^0.14.0",
+                        "@szmarczak/http-timer": "^1.1.2",
+                        "cacheable-request": "^6.0.0",
+                        "decompress-response": "^3.3.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^4.1.0",
+                        "lowercase-keys": "^1.0.1",
+                        "mimic-response": "^1.0.1",
+                        "p-cancelable": "^1.0.0",
+                        "to-readable-stream": "^1.0.0",
+                        "url-parse-lax": "^3.0.0"
+                    }
+                },
+                "http-cache-semantics": {
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+                    "integrity": "sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA==",
+                    "dev": true
+                },
+                "normalize-url": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+                    "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+                    "dev": true
+                },
+                "p-cancelable": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
+                    "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
+                    "dev": true
+                },
+                "prepend-http": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+                    "dev": true
+                },
+                "url-parse-lax": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+                    "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "^2.0.0"
+                    }
+                }
             }
         },
         "pacote": {
@@ -14753,9 +12747,9 @@
             }
         },
         "pako": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-            "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
             "dev": true
         },
         "parallel-transform": {
@@ -15740,9 +13734,9 @@
             }
         },
         "protractor": {
-            "version": "5.4.2",
-            "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.4.2.tgz",
-            "integrity": "sha512-zlIj64Cr6IOWP7RwxVeD8O4UskLYPoyIcg0HboWJL9T79F1F0VWtKkGTr/9GN6BKL+/Q/GmM7C9kFVCfDbP5sA==",
+            "version": "5.4.3",
+            "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.4.3.tgz",
+            "integrity": "sha512-7pMAolv8Ah1yJIqaorDTzACtn3gk7BamVKPTeO5lqIGOrfosjPgXFx/z1dqSI+m5EeZc2GMJHPr5DYlodujDNA==",
             "dev": true,
             "requires": {
                 "@types/q": "^0.0.32",
@@ -15762,6 +13756,12 @@
                 "webdriver-manager": "^12.0.6"
             },
             "dependencies": {
+                "@types/q": {
+                    "version": "0.0.32",
+                    "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+                    "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
+                    "dev": true
+                },
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -15838,6 +13838,12 @@
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                },
+                "q": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+                    "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
                     "dev": true
                 },
                 "semver": {
@@ -15970,9 +13976,9 @@
             "dev": true
         },
         "q": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-            "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
             "dev": true
         },
         "qjobs": {
@@ -16145,6 +14151,15 @@
                 "text-table": "0.2.0"
             },
             "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.5.5",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+                    "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "^7.0.0"
+                    }
+                },
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -16163,9 +14178,9 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001025",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001025.tgz",
-                    "integrity": "sha512-SKyFdHYfXUZf5V85+PJgLYyit27q4wgvZuf8QTOk1osbypcROihMBlx9GRar2/pIcKH2r4OehdlBr9x6PXetAQ==",
+                    "version": "1.0.30001027",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz",
+                    "integrity": "sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==",
                     "dev": true
                 },
                 "debug": {
@@ -16314,39 +14329,64 @@
             }
         },
         "read-pkg": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "@types/normalize-package-data": "^2.4.0",
-                "normalize-package-data": "^2.5.0",
-                "parse-json": "^5.0.0",
-                "type-fest": "^0.6.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             },
             "dependencies": {
-                "parse-json": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-                    "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+                "path-type": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                    "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "error-ex": "^1.3.1",
-                        "json-parse-better-errors": "^1.0.1",
-                        "lines-and-columns": "^1.1.6"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 }
             }
         },
         "read-pkg-up": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
-            "integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "^3.0.0",
-                "read-pkg": "^5.0.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                    "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                    "dev": true,
+                    "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "^2.0.0"
+                    }
+                }
             }
         },
         "readable-stream": {
@@ -16481,13 +14521,12 @@
             }
         },
         "registry-auth-token": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.0.0.tgz",
-            "integrity": "sha512-lpQkHxd9UL6tb3k/aHAVfnVtn+Bcs9ob5InuFLLEDqSqeq+AljB8GZW9xY0x7F+xYwEcjKe07nyoxzEYz6yvkw==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+            "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
             "dev": true,
             "requires": {
-                "rc": "^1.2.8",
-                "safe-buffer": "^5.0.1"
+                "rc": "^1.2.8"
             }
         },
         "registry-url": {
@@ -16577,9 +14616,9 @@
             "dev": true
         },
         "request": {
-            "version": "2.88.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "version": "2.88.2",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
@@ -16589,7 +14628,7 @@
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
                 "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
+                "har-validator": "~5.1.3",
                 "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
@@ -16599,7 +14638,7 @@
                 "performance-now": "^2.1.0",
                 "qs": "~6.5.2",
                 "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
+                "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^3.3.2"
             }
@@ -16623,9 +14662,9 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
-            "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+            "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
             "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
@@ -17302,14 +15341,6 @@
                 "lodash.padstart": "^4.6.1",
                 "whatwg-url": "^7.0.0",
                 "xmlbuilder": "^13.0.0"
-            },
-            "dependencies": {
-                "xmlbuilder": {
-                    "version": "13.0.2",
-                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
-                    "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
-                    "dev": true
-                }
             }
         },
         "slash": {
@@ -17700,9 +15731,9 @@
             "dev": true
         },
         "sourcemap-codec": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.7.tgz",
-            "integrity": "sha512-RuN23NzhAOuUtaivhcrjXx1OPXsFeH9m5sI373/U7+tGLKihjUyboZAzOadytMjnqHp1f45RGk1IzDKCpDpSYA==",
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
             "dev": true
         },
         "spdx-correct": {
@@ -17797,9 +15828,9 @@
                     "dev": true
                 },
                 "readable-stream": {
-                    "version": "3.4.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-                    "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.5.0.tgz",
+                    "integrity": "sha512-gSz026xs2LfxBPudDuI41V1lka8cxg64E66SGe78zJlsUofOg/yqwezdIcdfwik6B4h8LFmWPA9ef9X3FiNFLA==",
                     "dev": true,
                     "requires": {
                         "inherits": "^2.0.3",
@@ -17991,6 +16022,17 @@
                         "ms": "^2.1.1"
                     }
                 },
+                "fs-extra": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -18077,10 +16119,13 @@
             }
         },
         "strip-bom": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-            "dev": true
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "^0.2.0"
+            }
         },
         "strip-color": {
             "version": "0.1.0",
@@ -18394,9 +16439,9 @@
             }
         },
         "terser": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.2.tgz",
-            "integrity": "sha512-6FUjJdY2i3WZAtYBtnV06OOcOfzl+4hSKYE9wgac8rkLRBToPDDrBB2AcHwQD/OKDxbnvhVy2YgOPWO2SsKWqg==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.3.tgz",
+            "integrity": "sha512-Lw+ieAXmY69d09IIc/yqeBqXpEQIpDGZqT34ui1QWXIUpR2RjbqEkT8X7Lgex19hslSqcWM5iMN2kM11eMsESQ==",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -18618,21 +16663,13 @@
             "dev": true
         },
         "tough-cookie": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "dev": true,
             "requires": {
-                "psl": "^1.1.24",
-                "punycode": "^1.4.1"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true
-                }
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
             }
         },
         "tr46": {
@@ -18814,26 +16851,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
             "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
             "dev": true
-        },
-        "uglify-js": {
-            "version": "3.7.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
-            "integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
-            "dev": true,
-            "optional": true,
-            "requires": {
-                "commander": "~2.20.3",
-                "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true,
-                    "optional": true
-                }
-            }
         },
         "ultron": {
             "version": "1.1.1",
@@ -19052,6 +17069,14 @@
                 "latest-version": "^5.0.0",
                 "semver-diff": "^2.0.0",
                 "xdg-basedir": "^3.0.0"
+            },
+            "dependencies": {
+                "import-lazy": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
+                    "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+                    "dev": true
+                }
             }
         },
         "uri-js": {
@@ -19098,20 +17123,12 @@
             }
         },
         "url-parse-lax": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+            "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "dev": true,
             "requires": {
-                "prepend-http": "^2.0.0"
-            },
-            "dependencies": {
-                "prepend-http": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-                    "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-                    "dev": true
-                }
+                "prepend-http": "^1.0.1"
             }
         },
         "url-to-options": {
@@ -19196,27 +17213,6 @@
                 "es-abstract": "^1.17.2",
                 "has-symbols": "^1.0.1",
                 "object.getownpropertydescriptors": "^2.1.0"
-            },
-            "dependencies": {
-                "es-abstract": {
-                    "version": "1.17.4",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-                    "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-                    "dev": true,
-                    "requires": {
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.1",
-                        "is-callable": "^1.1.5",
-                        "is-regex": "^1.0.5",
-                        "object-inspect": "^1.7.0",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.0",
-                        "string.prototype.trimleft": "^2.1.1",
-                        "string.prototype.trimright": "^2.1.1"
-                    }
-                }
             }
         },
         "utils-merge": {
@@ -19226,9 +17222,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-            "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "dev": true
         },
         "validate-npm-package-license": {
@@ -19396,29 +17392,25 @@
                     "dependencies": {
                         "abbrev": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-                            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "are-we-there-yet": {
                             "version": "1.1.5",
-                            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-                            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19428,15 +17420,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
-                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-                            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19446,43 +17436,37 @@
                         },
                         "chownr": {
                             "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-                            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "debug": {
                             "version": "3.2.6",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19491,29 +17475,25 @@
                         },
                         "deep-extend": {
                             "version": "0.6.0",
-                            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-                            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "delegates": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "detect-libc": {
                             "version": "1.0.3",
-                            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-                            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "fs-minipass": {
                             "version": "1.2.7",
-                            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-                            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19522,15 +17502,13 @@
                         },
                         "fs.realpath": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "gauge": {
                             "version": "2.7.4",
-                            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19546,8 +17524,7 @@
                         },
                         "glob": {
                             "version": "7.1.6",
-                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-                            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19561,15 +17538,13 @@
                         },
                         "has-unicode": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "iconv-lite": {
                             "version": "0.4.24",
-                            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19578,8 +17553,7 @@
                         },
                         "ignore-walk": {
                             "version": "3.0.3",
-                            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-                            "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19588,8 +17562,7 @@
                         },
                         "inflight": {
                             "version": "1.0.6",
-                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19599,22 +17572,19 @@
                         },
                         "inherits": {
                             "version": "2.0.4",
-                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
-                            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-                            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19623,15 +17593,13 @@
                         },
                         "isarray": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "minimatch": {
                             "version": "3.0.4",
-                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19640,15 +17608,13 @@
                         },
                         "minimist": {
                             "version": "0.0.8",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "minipass": {
                             "version": "2.9.0",
-                            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19658,8 +17624,7 @@
                         },
                         "minizlib": {
                             "version": "1.3.3",
-                            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-                            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19668,8 +17633,7 @@
                         },
                         "mkdirp": {
                             "version": "0.5.1",
-                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19678,15 +17642,13 @@
                         },
                         "ms": {
                             "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "needle": {
                             "version": "2.4.0",
-                            "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-                            "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19697,8 +17659,7 @@
                         },
                         "node-pre-gyp": {
                             "version": "0.14.0",
-                            "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-                            "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19716,8 +17677,7 @@
                         },
                         "nopt": {
                             "version": "4.0.1",
-                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-                            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19727,8 +17687,7 @@
                         },
                         "npm-bundled": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-                            "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19737,15 +17696,13 @@
                         },
                         "npm-normalize-package-bin": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-                            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "npm-packlist": {
                             "version": "1.4.7",
-                            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
-                            "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19755,8 +17712,7 @@
                         },
                         "npmlog": {
                             "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-                            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19768,22 +17724,19 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "once": {
                             "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19792,22 +17745,19 @@
                         },
                         "os-homedir": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "os-tmpdir": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "osenv": {
                             "version": "0.1.5",
-                            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-                            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19817,22 +17767,19 @@
                         },
                         "path-is-absolute": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "process-nextick-args": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-                            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "rc": {
                             "version": "1.2.8",
-                            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-                            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19844,8 +17791,7 @@
                             "dependencies": {
                                 "minimist": {
                                     "version": "1.2.0",
-                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                                    "bundled": true,
                                     "dev": true,
                                     "optional": true
                                 }
@@ -19853,8 +17799,7 @@
                         },
                         "readable-stream": {
                             "version": "2.3.6",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19869,8 +17814,7 @@
                         },
                         "rimraf": {
                             "version": "2.7.1",
-                            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19879,50 +17823,43 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-                            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "sax": {
                             "version": "1.2.4",
-                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-                            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "semver": {
                             "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "set-blocking": {
                             "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "signal-exit": {
                             "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19933,8 +17870,7 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19943,8 +17879,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19953,15 +17888,13 @@
                         },
                         "strip-json-comments": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "tar": {
                             "version": "4.4.13",
-                            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-                            "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19976,15 +17909,13 @@
                         },
                         "util-deprecate": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "wide-align": {
                             "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-                            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -19993,15 +17924,13 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "yallist": {
                             "version": "3.1.1",
-                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         }
@@ -20308,29 +18237,25 @@
                     "dependencies": {
                         "abbrev": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-                            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-                            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "are-we-there-yet": {
                             "version": "1.1.5",
-                            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-                            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20340,15 +18265,13 @@
                         },
                         "balanced-match": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
-                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-                            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20358,43 +18281,37 @@
                         },
                         "chownr": {
                             "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-                            "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "code-point-at": {
                             "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
-                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "debug": {
                             "version": "3.2.6",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20403,29 +18320,25 @@
                         },
                         "deep-extend": {
                             "version": "0.6.0",
-                            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-                            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "delegates": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "detect-libc": {
                             "version": "1.0.3",
-                            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-                            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "fs-minipass": {
                             "version": "1.2.7",
-                            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-                            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20434,15 +18347,13 @@
                         },
                         "fs.realpath": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "gauge": {
                             "version": "2.7.4",
-                            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20458,8 +18369,7 @@
                         },
                         "glob": {
                             "version": "7.1.6",
-                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-                            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20473,15 +18383,13 @@
                         },
                         "has-unicode": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "iconv-lite": {
                             "version": "0.4.24",
-                            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-                            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20490,8 +18398,7 @@
                         },
                         "ignore-walk": {
                             "version": "3.0.3",
-                            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-                            "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20500,8 +18407,7 @@
                         },
                         "inflight": {
                             "version": "1.0.6",
-                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20511,22 +18417,19 @@
                         },
                         "inherits": {
                             "version": "2.0.4",
-                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-                            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
-                            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-                            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "is-fullwidth-code-point": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20535,15 +18438,13 @@
                         },
                         "isarray": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "minimatch": {
                             "version": "3.0.4",
-                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20552,15 +18453,13 @@
                         },
                         "minimist": {
                             "version": "0.0.8",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "minipass": {
                             "version": "2.9.0",
-                            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20570,8 +18469,7 @@
                         },
                         "minizlib": {
                             "version": "1.3.3",
-                            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-                            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20580,8 +18478,7 @@
                         },
                         "mkdirp": {
                             "version": "0.5.1",
-                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20590,15 +18487,13 @@
                         },
                         "ms": {
                             "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "needle": {
                             "version": "2.4.0",
-                            "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-                            "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20609,8 +18504,7 @@
                         },
                         "node-pre-gyp": {
                             "version": "0.14.0",
-                            "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
-                            "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20628,8 +18522,7 @@
                         },
                         "nopt": {
                             "version": "4.0.1",
-                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-                            "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20639,8 +18532,7 @@
                         },
                         "npm-bundled": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
-                            "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20649,15 +18541,13 @@
                         },
                         "npm-normalize-package-bin": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-                            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "npm-packlist": {
                             "version": "1.4.7",
-                            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
-                            "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20667,8 +18557,7 @@
                         },
                         "npmlog": {
                             "version": "4.1.2",
-                            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-                            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20680,22 +18569,19 @@
                         },
                         "number-is-nan": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "once": {
                             "version": "1.4.0",
-                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20704,22 +18590,19 @@
                         },
                         "os-homedir": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "os-tmpdir": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "osenv": {
                             "version": "0.1.5",
-                            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-                            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20729,22 +18612,19 @@
                         },
                         "path-is-absolute": {
                             "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "process-nextick-args": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-                            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "rc": {
                             "version": "1.2.8",
-                            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-                            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20756,8 +18636,7 @@
                             "dependencies": {
                                 "minimist": {
                                     "version": "1.2.0",
-                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                                    "bundled": true,
                                     "dev": true,
                                     "optional": true
                                 }
@@ -20765,8 +18644,7 @@
                         },
                         "readable-stream": {
                             "version": "2.3.6",
-                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20781,8 +18659,7 @@
                         },
                         "rimraf": {
                             "version": "2.7.1",
-                            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20791,50 +18668,43 @@
                         },
                         "safe-buffer": {
                             "version": "5.1.2",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
-                            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-                            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "sax": {
                             "version": "1.2.4",
-                            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-                            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "semver": {
                             "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "set-blocking": {
                             "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "signal-exit": {
                             "version": "3.0.2",
-                            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "string-width": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20845,8 +18715,7 @@
                         },
                         "string_decoder": {
                             "version": "1.1.1",
-                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20855,8 +18724,7 @@
                         },
                         "strip-ansi": {
                             "version": "3.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20865,15 +18733,13 @@
                         },
                         "strip-json-comments": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "tar": {
                             "version": "4.4.13",
-                            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-                            "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20888,15 +18754,13 @@
                         },
                         "util-deprecate": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "wide-align": {
                             "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-                            "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true,
                             "requires": {
@@ -20905,15 +18769,13 @@
                         },
                         "wrappy": {
                             "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         },
                         "yallist": {
                             "version": "3.1.1",
-                            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+                            "bundled": true,
                             "dev": true,
                             "optional": true
                         }
@@ -21089,9 +18951,9 @@
             }
         },
         "wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+            "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
             "dev": true
         },
         "worker-farm": {
@@ -21219,13 +19081,19 @@
                     "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
                     "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
                     "dev": true
+                },
+                "xmlbuilder": {
+                    "version": "11.0.1",
+                    "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+                    "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+                    "dev": true
                 }
             }
         },
         "xmlbuilder": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+            "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
             "dev": true
         },
         "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
         "@ngrx/store": "^8.5.2",
         "@ngrx/store-devtools": "^8.5.2",
         "fast-equals": "^2.0.0",
-        "ngrx-clean-forms": "file:dist/ngrx-clean-forms",
         "rxjs": "~6.4.0",
         "tslib": "^1.10.0",
-        "zone.js": "~0.9.1"
+        "zone.js": "~0.9.1",
+        "ngrx-clean-forms": "file:dist/ngrx-clean-forms"
     },
     "devDependencies": {
         "@angular-devkit/build-angular": "~0.802.0",

--- a/projects/example-app/src/app/app.component.scss
+++ b/projects/example-app/src/app/app.component.scss
@@ -9,3 +9,7 @@
 .ng-invalid {
     background-color: orange;
 }
+
+.ng-initial {
+    font-style: italic;
+}

--- a/projects/ngrx-clean-forms/package.json
+++ b/projects/ngrx-clean-forms/package.json
@@ -23,9 +23,10 @@
         "typescript",
         "redux"
     ],
-    "version": "4.2.0",
+    "version": "4.3.0",
     "peerDependencies": {
         "@angular/common": "^8.2.0",
-        "@angular/core": "^8.2.0"
+        "@angular/core": "^8.2.0",
+        "fast-equals": "^2.0.0"
     }
 }

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/abstract-control.directive.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/abstract-control.directive.spec.ts
@@ -53,106 +53,32 @@ describe('AbstractControlDirective', () => {
     });
 
     describe('cssClasses', () => {
-        it('{pristine: true} sets ng-pristine and unsets ng-dirty', () => {
-            testComponent.componentInstance.summary$.next({
-                ...getFormControlSummary(initFormControl([''])),
-                pristine: true,
+        [
+            [{ pristine: true }, 'ng-pristine', 'ng-dirty'],
+            [{ pristine: false }, 'ng-dirty', 'ng-pristine'],
+            [{ valid: true }, 'ng-valid', 'ng-invalid'],
+            [{ valid: false }, 'ng-invalid', 'ng-valid'],
+            [{ untouched: true }, 'ng-untouched', 'ng-touched'],
+            [{ untouched: false }, 'ng-touched', 'ng-untouched'],
+            [{ changed: true }, 'ng-changed', 'ng-initial'],
+            [{ changed: false }, 'ng-initial', 'ng-changed'],
+        ].forEach(([update, shouldSet, shouldUnset]) => {
+            it(`${update} should set ${shouldSet} and unset ${shouldUnset}`, () => {
+                testComponent.componentInstance.summary$.next({
+                    ...getFormControlSummary(initFormControl([''])),
+                    ...(update as Partial<FormControlSummary<any>>),
+                });
+
+                testComponent.detectChanges();
+
+                // tslint:disable-next-line: no-string-literal
+                const isPristine = directive['ref'].nativeElement.classList.contains(shouldSet);
+                // tslint:disable-next-line: no-string-literal
+                const isDirty = directive['ref'].nativeElement.classList.contains(shouldUnset);
+
+                expect(isPristine).toBe(true);
+                expect(isDirty).toBe(false);
             });
-
-            testComponent.detectChanges();
-
-            // tslint:disable-next-line: no-string-literal
-            const isPristine = directive['ref'].nativeElement.classList.contains('ng-pristine');
-            // tslint:disable-next-line: no-string-literal
-            const isDirty = directive['ref'].nativeElement.classList.contains('ng-dirty');
-
-            expect(isPristine).toBe(true);
-            expect(isDirty).toBe(false);
-        });
-
-        it('{pristine: false} sets ng-dirty and unsets ng-pristine', () => {
-            testComponent.componentInstance.summary$.next({
-                ...getFormControlSummary(initFormControl([''])),
-                pristine: false,
-            });
-
-            testComponent.detectChanges();
-
-            // tslint:disable-next-line: no-string-literal
-            const isPristine = directive['ref'].nativeElement.classList.contains('ng-pristine');
-            // tslint:disable-next-line: no-string-literal
-            const isDirty = directive['ref'].nativeElement.classList.contains('ng-dirty');
-
-            expect(isPristine).toBe(false);
-            expect(isDirty).toBe(true);
-        });
-
-        it('{valid: true} sets ng-valid and unsets ng-invalid', () => {
-            testComponent.componentInstance.summary$.next({
-                ...getFormControlSummary(initFormControl([''])),
-                valid: true,
-            });
-
-            testComponent.detectChanges();
-
-            // tslint:disable-next-line: no-string-literal
-            const isValid = directive['ref'].nativeElement.classList.contains('ng-valid');
-            // tslint:disable-next-line: no-string-literal
-            const isInvalid = directive['ref'].nativeElement.classList.contains('ng-invalid');
-
-            expect(isValid).toBe(true);
-            expect(isInvalid).toBe(false);
-        });
-
-        it('{valid: false} sets ng-invalid and unsets ng-valid', () => {
-            testComponent.componentInstance.summary$.next({
-                ...getFormControlSummary(initFormControl([''])),
-                valid: false,
-            });
-
-            testComponent.detectChanges();
-
-            // tslint:disable-next-line: no-string-literal
-            const isValid = directive['ref'].nativeElement.classList.contains('ng-valid');
-            // tslint:disable-next-line: no-string-literal
-            const isInvalid = directive['ref'].nativeElement.classList.contains('ng-invalid');
-
-            expect(isValid).toBe(false);
-            expect(isInvalid).toBe(true);
-        });
-
-        it('{untouched: true} sets ng-untouched and unsets ng-touched', () => {
-            testComponent.componentInstance.summary$.next({
-                ...getFormControlSummary(initFormControl([''])),
-                untouched: true,
-            });
-
-            testComponent.detectChanges();
-
-            // tslint:disable-next-line: no-string-literal
-            const isUntouched = directive['ref'].nativeElement.classList.contains('ng-untouched');
-            // tslint:disable-next-line: no-string-literal
-            const isTouched = directive['ref'].nativeElement.classList.contains('ng-touched');
-
-            expect(isUntouched).toBe(true);
-            expect(isTouched).toBe(false);
-        });
-
-        it('{untouched: false} sets ng-touched and unsets ng-untouched', () => {
-            testComponent.componentInstance.summary$.next({
-                ...getFormControlSummary(initFormControl([''])),
-                untouched: false,
-            });
-
-            testComponent.detectChanges();
-
-            // tslint:disable-next-line: no-string-literal
-            const isUntouched = directive['ref'].nativeElement.classList.contains('ng-untouched');
-            // tslint:disable-next-line: no-string-literal
-            const isTouched = directive['ref'].nativeElement.classList.contains('ng-touched');
-
-            expect(isUntouched).toBe(false);
-            expect(isTouched).toBe(true);
         });
     });
 

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/abstract-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/abstract-control.directive.ts
@@ -19,6 +19,8 @@ const cssClasses = {
     dirty: 'ng-dirty',
     touched: 'ng-touched',
     untouched: 'ng-untouched',
+    changed: 'ng-changed',
+    initial: 'ng-initial',
 };
 
 export const CONTROL_DIRECTIVE_SELECTOR = `ngrxFormControl`;
@@ -87,6 +89,7 @@ export abstract class AbstractControlDirective<T> implements OnDestroy {
         this.chooseClass(cssClasses.invalid, cssClasses.valid, summary.valid);
         this.chooseClass(cssClasses.dirty, cssClasses.pristine, summary.pristine);
         this.chooseClass(cssClasses.touched, cssClasses.untouched, summary.untouched);
+        this.chooseClass(cssClasses.initial, cssClasses.changed, summary.changed);
     }
 
     chooseClass(class1: string, class2: string, chooseSecond: boolean) {

--- a/projects/ngrx-clean-forms/src/lib/init.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/init.spec.ts
@@ -10,6 +10,7 @@ describe('init', () => {
             it('["value"] should create a valid form control state', () => {
                 const expected: FormControlState<string> = {
                     value,
+                    initialValue: value,
                     disabled: false,
                     pristine: true,
                     untouched: true,
@@ -24,6 +25,7 @@ describe('init', () => {
             it('["value", [() => null]] should create a valid form control state with validator', () => {
                 const expected: FormControlState<string> = {
                     value,
+                    initialValue: value,
                     disabled: false,
                     pristine: true,
                     untouched: true,
@@ -40,6 +42,7 @@ describe('init', () => {
             it('{value: value} should create a valid form control state', () => {
                 const expected: FormControlState<string> = {
                     value,
+                    initialValue: value,
                     disabled: false,
                     pristine: true,
                     untouched: true,
@@ -54,6 +57,7 @@ describe('init', () => {
             it('["value", [() => null]] should create a valid form control state with validator', () => {
                 const expected: FormControlState<string> = {
                     value,
+                    initialValue: value,
                     disabled: false,
                     pristine: true,
                     untouched: true,
@@ -68,6 +72,7 @@ describe('init', () => {
             it('{value: value, disabled: true, pristine: false, untouched: false} should create a valid form control state', () => {
                 const expected: FormControlState<string> = {
                     value,
+                    initialValue: value,
                     disabled: true,
                     pristine: false,
                     untouched: false,
@@ -80,6 +85,43 @@ describe('init', () => {
                     pristine: expected.pristine,
                     untouched: expected.untouched,
                     validators: [],
+                });
+
+                expect(result).toEqual(expected);
+            });
+
+            it('value only should set initialValue', () => {
+                const expected: FormControlState<string> = {
+                    value,
+                    initialValue: value,
+                    disabled: false,
+                    pristine: true,
+                    untouched: true,
+                    validators: [],
+                };
+
+                const result = initFormControl({
+                    value,
+                });
+
+                expect(result).toEqual(expected);
+            });
+
+            it('intialValue should set initialValue', () => {
+                const initialValue = 'initial';
+
+                const expected: FormControlState<string> = {
+                    value,
+                    initialValue,
+                    disabled: false,
+                    pristine: true,
+                    untouched: true,
+                    validators: [],
+                };
+
+                const result = initFormControl({
+                    value,
+                    initialValue,
                 });
 
                 expect(result).toEqual(expected);
@@ -97,6 +139,7 @@ describe('init', () => {
                         untouched: true,
                         validators: [validator],
                         value,
+                        initialValue: value,
                     },
                     update: {
                         disabled: true,
@@ -104,6 +147,7 @@ describe('init', () => {
                         untouched: false,
                         validators: [validator],
                         value,
+                        initialValue: value,
                     },
                 },
             };
@@ -133,6 +177,7 @@ describe('init', () => {
                         disabled: false,
                         pristine: true,
                         untouched: true,
+                        initialValue: value,
                     },
                 ],
             };
@@ -151,6 +196,7 @@ describe('init', () => {
                         disabled: true,
                         pristine: false,
                         untouched: false,
+                        initialValue: value,
                     },
                 ],
             };

--- a/projects/ngrx-clean-forms/src/lib/init.ts
+++ b/projects/ngrx-clean-forms/src/lib/init.ts
@@ -81,6 +81,7 @@ function initFormControlFromUpdate<T = any>(
     return reduceFormControl(
         {
             value: undefined,
+            initialValue: initialUpdate.value,
             pristine: true,
             untouched: true,
             disabled: false,

--- a/projects/ngrx-clean-forms/src/lib/reducer.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/reducer.spec.ts
@@ -130,6 +130,7 @@ describe('reducer', () => {
 
         it('array update should only update affected', () => {
             const value = 'value';
+            const initialValue = 'initial';
             const pristine = false;
 
             const controlUpdate: FormControlUpdate<string> = {
@@ -137,7 +138,7 @@ describe('reducer', () => {
                 pristine,
             };
 
-            const array = initFormArray([['1'], ['2'], ['3'], ['4']]);
+            const array = initFormArray([['1'], [initialValue], ['3'], ['4']]);
 
             const update: FormArrayUpdate<string> = {
                 controls: [null, controlUpdate, null],
@@ -146,7 +147,7 @@ describe('reducer', () => {
             const expected: FormArrayState<string> = {
                 controls: [
                     initFormControl(['1']),
-                    initFormControl({ value, pristine }),
+                    initFormControl({ value, pristine, initialValue }),
                     initFormControl(['3']),
                     initFormControl(['4']),
                 ],

--- a/projects/ngrx-clean-forms/src/lib/selectors.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/selectors.spec.ts
@@ -198,6 +198,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 value: '',
+                initialValue: '',
                 validators: [],
                 disabled: false,
             };
@@ -206,6 +207,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 value: '',
+                initialValue: '',
                 validators: [],
                 disabled: false,
                 errors: null,
@@ -228,6 +230,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 value: '',
+                initialValue: '',
                 validators,
                 disabled: false,
             };
@@ -236,6 +239,7 @@ describe('selectors', () => {
                 pristine: control.pristine,
                 untouched: control.untouched,
                 value: control.value,
+                initialValue: '',
                 validators,
                 disabled: false,
                 errors: error,
@@ -256,6 +260,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 value: '',
+                initialValue: '',
                 validators: [],
                 disabled: false,
             };
@@ -265,6 +270,7 @@ describe('selectors', () => {
                 untouched: control.untouched,
                 value: control.value,
                 validators: [],
+                initialValue: '',
                 disabled: false,
                 errors: additionalError,
                 valid: false,
@@ -290,6 +296,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 value: '',
+                initialValue: '',
                 validators,
                 disabled: false,
             };
@@ -298,6 +305,7 @@ describe('selectors', () => {
                 pristine: control.pristine,
                 untouched: control.untouched,
                 value: control.value,
+                initialValue: '',
                 validators,
                 disabled: false,
                 errors: { alwaysTrue: true, additionalError: true },
@@ -512,6 +520,7 @@ describe('selectors', () => {
                 controls: {
                     stringControl: {
                         value: 'initial',
+                        initialValue: 'initial',
                         disabled: false,
                         pristine: true,
                         untouched: true,
@@ -554,6 +563,7 @@ describe('selectors', () => {
                 controls: {
                     stringControl: {
                         value: 'initial',
+                        initialValue: 'initial',
                         disabled: false,
                         pristine: true,
                         untouched: true,
@@ -595,6 +605,7 @@ describe('selectors', () => {
                 controls: {
                     stringControl: {
                         value: 'initial',
+                        initialValue: 'initial',
                         disabled: false,
                         pristine: true,
                         untouched: true,
@@ -629,6 +640,7 @@ describe('selectors', () => {
                 controls: {
                     stringControl: {
                         value: 'initial',
+                        initialValue: 'initial',
                         disabled: false,
                         pristine: true,
                         untouched: true,
@@ -691,6 +703,7 @@ describe('selectors', () => {
                 controls: [
                     {
                         value: 'initial',
+                        initialValue: 'initial',
                         disabled: false,
                         pristine: true,
                         untouched: true,
@@ -732,6 +745,7 @@ describe('selectors', () => {
                 controls: [
                     {
                         value: 'initial',
+                        initialValue: 'initial',
                         disabled: false,
                         pristine: true,
                         untouched: true,
@@ -769,6 +783,7 @@ describe('selectors', () => {
                 controls: [
                     {
                         value: 'initial',
+                        initialValue: 'initial',
                         disabled: false,
                         pristine: true,
                         untouched: true,
@@ -802,6 +817,7 @@ describe('selectors', () => {
                 controls: [
                     {
                         value: 'initial',
+                        initialValue: 'initial',
                         disabled: false,
                         pristine: true,
                         untouched: true,

--- a/projects/ngrx-clean-forms/src/lib/selectors.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/selectors.spec.ts
@@ -12,6 +12,7 @@ import {
     getFormArrayControlSummaries,
     getFormArrayPristine,
     getFormArrayUntouched,
+    getFormGroupChanged,
 } from './selectors';
 import {
     FormControlErrors,
@@ -462,6 +463,41 @@ describe('selectors', () => {
         });
     });
 
+    describe('getFormGroupChanged', () => {
+        it('only initial values should return false', () => {
+            const result = getFormGroupChanged({
+                first: getFormControlSummary(initFormControl(['value'])),
+                second: getFormControlSummary(initFormControl(['value'])),
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('one changed value should return true', () => {
+            const result = getFormGroupChanged({
+                first: getFormControlSummary(initFormControl(['value'])),
+                second: getFormControlSummary(
+                    initFormControl({ value: 'value', initialValue: 'changed' })
+                ),
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('all changed values should return true', () => {
+            const result = getFormGroupChanged({
+                first: getFormControlSummary(
+                    initFormControl({ value: 'value', initialValue: 'changed' })
+                ),
+                second: getFormControlSummary(
+                    initFormControl({ value: 'value', initialValue: 'changed' })
+                ),
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+
     describe('getFormArrayUntouched', () => {
         it('all controls untouched should return true', () => {
             const array = {
@@ -578,6 +614,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 valid: false,
+                changed: false,
             };
 
             const result = getFormGroupSummary(group, additionalError);
@@ -620,6 +657,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 valid: false,
+                changed: false,
             };
 
             const result = getFormGroupSummary(group, additionalError);
@@ -663,6 +701,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 valid: false,
+                changed: false,
             };
 
             const result = getFormGroupSummary(group);
@@ -693,6 +732,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 valid: true,
+                changed: false,
             };
 
             const result = getFormGroupSummary(group);

--- a/projects/ngrx-clean-forms/src/lib/selectors.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/selectors.spec.ts
@@ -13,6 +13,7 @@ import {
     getFormArrayPristine,
     getFormArrayUntouched,
     getFormGroupChanged,
+    getFormArrayChanged,
 } from './selectors';
 import {
     FormControlErrors,
@@ -463,6 +464,42 @@ describe('selectors', () => {
         });
     });
 
+    describe('getFormArrayUntouched', () => {
+        it('all controls untouched should return true', () => {
+            const array = {
+                controls: [
+                    {
+                        untouched: true,
+                    } as FormControlState<any>,
+                    {
+                        untouched: true,
+                    } as FormControlState<any>,
+                ],
+            };
+
+            const result = getFormArrayUntouched(array);
+
+            expect(result).toEqual(true);
+        });
+
+        it('one control touched should return false', () => {
+            const array = {
+                controls: [
+                    {
+                        untouched: true,
+                    } as FormControlState<any>,
+                    {
+                        untouched: false,
+                    } as FormControlState<any>,
+                ],
+            };
+
+            const result = getFormArrayUntouched(array);
+
+            expect(result).toEqual(false);
+        });
+    });
+
     describe('getFormGroupChanged', () => {
         it('only initial values should return false', () => {
             const result = getFormGroupChanged({
@@ -498,39 +535,38 @@ describe('selectors', () => {
         });
     });
 
-    describe('getFormArrayUntouched', () => {
-        it('all controls untouched should return true', () => {
-            const array = {
-                controls: [
-                    {
-                        untouched: true,
-                    } as FormControlState<any>,
-                    {
-                        untouched: true,
-                    } as FormControlState<any>,
-                ],
-            };
+    describe('getFormArrayChanged', () => {
+        it('only initial values should return false', () => {
+            const result = getFormArrayChanged([
+                getFormControlSummary(initFormControl(['value'])),
+                getFormControlSummary(initFormControl(['value'])),
+            ]);
 
-            const result = getFormArrayUntouched(array);
-
-            expect(result).toEqual(true);
+            expect(result).toBe(false);
         });
 
-        it('one control touched should return false', () => {
-            const array = {
-                controls: [
-                    {
-                        untouched: true,
-                    } as FormControlState<any>,
-                    {
-                        untouched: false,
-                    } as FormControlState<any>,
-                ],
-            };
+        it('one changed value should return true', () => {
+            const result = getFormArrayChanged([
+                getFormControlSummary(initFormControl(['value'])),
+                getFormControlSummary(
+                    initFormControl({ value: 'value', initialValue: 'initialValue' })
+                ),
+            ]);
 
-            const result = getFormArrayUntouched(array);
+            expect(result).toBe(true);
+        });
 
-            expect(result).toEqual(false);
+        it('all changed values should return true', () => {
+            const result = getFormArrayChanged([
+                getFormControlSummary(
+                    initFormControl({ value: 'value', initialValue: 'initialValue' })
+                ),
+                getFormControlSummary(
+                    initFormControl({ value: 'value', initialValue: 'initialValue' })
+                ),
+            ]);
+
+            expect(result).toBe(true);
         });
     });
 
@@ -806,6 +842,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 valid: false,
+                changed: false,
             };
 
             const result = getFormArraySummary(array, additionalError);
@@ -847,6 +884,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 valid: false,
+                changed: false,
             };
 
             const result = getFormArraySummary(array, additionalError);
@@ -886,6 +924,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 valid: false,
+                changed: false,
             };
 
             const result = getFormArraySummary(array);
@@ -915,6 +954,7 @@ describe('selectors', () => {
                 pristine: true,
                 untouched: true,
                 valid: true,
+                changed: false,
             };
 
             const result = getFormArraySummary(array);

--- a/projects/ngrx-clean-forms/src/lib/selectors.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/selectors.spec.ts
@@ -193,6 +193,38 @@ describe('selectors', () => {
     });
 
     describe('getFormControlSummary', () => {
+        [undefined, null, 0, { value: 'value' }].forEach(value => {
+            it(`${value} match should return changed: false`, () => {
+                const result = getFormControlSummary(initFormControl([value]));
+
+                expect(result.changed).toBe(false);
+            });
+        });
+
+        it('should return changed: true for changed simple value', () => {
+            const result = getFormControlSummary(
+                initFormControl({
+                    value: 'value',
+                    initialValue: 'initialValue',
+                })
+            );
+
+            expect(result.changed).toBe(true);
+        });
+
+        it('should return changed: true for object key value change', () => {
+            const result = getFormControlSummary(
+                initFormControl({
+                    value: { deeper: { deep: 'value' } },
+                    initialValue: { deeper: { deep: 'initialValue' } },
+                })
+            );
+
+            expect(result.changed).toBe(true);
+        });
+    });
+
+    describe('getFormControlSummary', () => {
         it('should return valid = true, errors = null, controls for valid control', () => {
             const control: FormControlState<string> = {
                 pristine: true,
@@ -212,6 +244,7 @@ describe('selectors', () => {
                 disabled: false,
                 errors: null,
                 valid: true,
+                changed: false,
             };
 
             const result = getFormControlSummary(control);
@@ -244,6 +277,7 @@ describe('selectors', () => {
                 disabled: false,
                 errors: error,
                 valid: false,
+                changed: false,
             };
 
             const result = getFormControlSummary(control);
@@ -274,6 +308,7 @@ describe('selectors', () => {
                 disabled: false,
                 errors: additionalError,
                 valid: false,
+                changed: false,
             };
 
             const result = getFormControlSummary(control, additionalError);
@@ -310,6 +345,7 @@ describe('selectors', () => {
                 disabled: false,
                 errors: { alwaysTrue: true, additionalError: true },
                 valid: false,
+                changed: false,
             };
 
             const result = getFormControlSummary(control, additionalError);
@@ -530,6 +566,7 @@ describe('selectors', () => {
                             externalError: true,
                             controlError: true,
                         },
+                        changed: false,
                     },
                 },
                 errors: {
@@ -572,6 +609,7 @@ describe('selectors', () => {
                         errors: {
                             externalError: true,
                         },
+                        changed: false,
                     },
                 },
                 errors: {
@@ -614,6 +652,7 @@ describe('selectors', () => {
                         errors: {
                             stringError: true,
                         },
+                        changed: false,
                     },
                 },
                 errors: {
@@ -647,6 +686,7 @@ describe('selectors', () => {
                         valid: true,
                         validators: group.controls.stringControl.validators,
                         errors: null,
+                        changed: false,
                     },
                 },
                 errors: null,
@@ -713,6 +753,7 @@ describe('selectors', () => {
                             externalError: true,
                             controlError: true,
                         },
+                        changed: false,
                     },
                 ],
                 keys: [0],
@@ -754,6 +795,7 @@ describe('selectors', () => {
                         errors: {
                             externalError: true,
                         },
+                        changed: false,
                     },
                 ],
                 keys: [0],
@@ -792,6 +834,7 @@ describe('selectors', () => {
                         errors: {
                             stringError: true,
                         },
+                        changed: false,
                     },
                 ],
                 keys: [0],
@@ -824,6 +867,7 @@ describe('selectors', () => {
                         valid: true,
                         validators: array.controls[0].validators,
                         errors: null,
+                        changed: false,
                     },
                 ],
                 keys: [0],

--- a/projects/ngrx-clean-forms/src/lib/selectors.ts
+++ b/projects/ngrx-clean-forms/src/lib/selectors.ts
@@ -20,6 +20,7 @@ import {
     mergeFormControlErrors,
     mergeFormArrayErrors,
 } from './utils';
+import { circularDeepEqual } from 'fast-equals';
 
 export function getFormControlErrors<T>(control: FormControlState<T>): FormControlErrors[] {
     return control.validators.map(validator => validator(control));
@@ -45,6 +46,10 @@ export function getFormArrayErrors<T>(
     return errors.filter(Boolean).length ? errors : null;
 }
 
+export function getFormControlChanged<T>(control: FormControlState<T>): boolean {
+    return !circularDeepEqual(control.value, control.initialValue);
+}
+
 /**
  * Creates a `FormControlSummary` from the given `FormControlState`.
  * It is possible to add additional errors.
@@ -62,6 +67,7 @@ export function getFormControlSummary<T>(
         ...control,
         errors,
         valid: errors === null,
+        changed: getFormControlChanged(control),
     };
 }
 

--- a/projects/ngrx-clean-forms/src/lib/selectors.ts
+++ b/projects/ngrx-clean-forms/src/lib/selectors.ts
@@ -109,6 +109,12 @@ export function getFormGroupUntouched<TControls extends FormControls>(
     return Object.values(group.controls).every(control => control.untouched);
 }
 
+export function getFormGroupChanged<TControls extends FormControls>(
+    controls: FormGroupControlSummaries<TControls>
+): boolean {
+    return Object.values(controls).some(control => control.changed);
+}
+
 export function getFormArrayUntouched<T>(array: FormArrayState<T>): boolean {
     return array.controls.every(control => control.untouched);
 }
@@ -137,6 +143,7 @@ export function getFormGroupSummary<TControls extends FormControls>(
         untouched: getFormGroupUntouched(group),
         errors,
         valid: errors === null,
+        changed: getFormGroupChanged(summaries),
     };
 }
 

--- a/projects/ngrx-clean-forms/src/lib/selectors.ts
+++ b/projects/ngrx-clean-forms/src/lib/selectors.ts
@@ -115,6 +115,10 @@ export function getFormGroupChanged<TControls extends FormControls>(
     return Object.values(controls).some(control => control.changed);
 }
 
+export function getFormArrayChanged<T>(controls: FormArrayControlSummaries<T>): boolean {
+    return controls.some(control => control.changed);
+}
+
 export function getFormArrayUntouched<T>(array: FormArrayState<T>): boolean {
     return array.controls.every(control => control.untouched);
 }
@@ -168,5 +172,6 @@ export function getFormArraySummary<T>(
         untouched: getFormArrayUntouched(array),
         errors,
         valid: errors === null,
+        changed: getFormArrayChanged(summaries),
     };
 }

--- a/projects/ngrx-clean-forms/src/lib/types.ts
+++ b/projects/ngrx-clean-forms/src/lib/types.ts
@@ -228,6 +228,14 @@ export interface FormGroupSummary<TControls extends FormControls>
      * Indicates whether all FormControls inside this group were not yet visited.
      */
     untouched: boolean;
+
+    /**
+     * Indicates whether any of the FormControls was changed.
+     * Comparison is always with the intial property of the FormControl.
+     *
+     * @see `FormControl`
+     */
+    changed: boolean;
 }
 
 /**

--- a/projects/ngrx-clean-forms/src/lib/types.ts
+++ b/projects/ngrx-clean-forms/src/lib/types.ts
@@ -275,4 +275,12 @@ export interface FormArraySummary<T> extends FormArrayState<T> {
      * Indicates whether all FormControls inside this array were not yet visited.
      */
     untouched: boolean;
+
+    /**
+     * Indicates whether any of the FormControls was changed.
+     * Comparison is always with the intial property of the FormControl.
+     *
+     * @see `FormControl`
+     */
+    changed: boolean;
 }

--- a/projects/ngrx-clean-forms/src/lib/types.ts
+++ b/projects/ngrx-clean-forms/src/lib/types.ts
@@ -183,6 +183,14 @@ export interface FormControlSummary<T> extends FormControlState<T> {
      * Whether the FormControl has any errors.
      */
     valid: boolean;
+
+    /**
+     * Whether the value is the same as the intial set value.
+     * Uses the `intialValue` property of the `FormControlState`.
+     *
+     * @see  `FormControlState`
+     */
+    changed: boolean;
 }
 
 export type FormGroupControlSummaries<TControls extends FormControls> = {

--- a/projects/ngrx-clean-forms/src/lib/types.ts
+++ b/projects/ngrx-clean-forms/src/lib/types.ts
@@ -111,7 +111,15 @@ export type FormArrayErrors = FormControlErrors[];
  * Represents the state of a single FormControl.
  */
 export interface FormControlState<T extends any> {
+    /**
+     * The value of this control.
+     */
     value: T;
+
+    /**
+     * The initial value of this control.
+     */
+    initialValue: T;
 
     /**
      * Indicates whether the value was not yet changed.


### PR DESCRIPTION
Resolves #20 

-   Every `FormControlState` now supports the `initialValue` property. It is set automatically when creating with one of the provided initializer functions.
-   Every `FormControlSummary` now additional supports the `changed` property. It is set to true when `initialValue` and `value` are different. For object comparison again [fast-equals](https://www.npmjs.com/package/fast-equals) was used.
    -   CSS class `.ng-changed` is now set on inputs when `changed: true`.
    -   CSS class `.ng-initial` is now set on inputs when `changed: false`.
-   `FormGroupSummary` and `FormGroupArray` also support the `changed` property. It is set when atleast one control was changed.