### PR TITLE
Add reset methods + disabled for initFormControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,14 @@ The configuration for an individual `FormControl` can also be overridden with th
 
 ## Changelog
 
-## 4.3.0
+### 4.4.0
+
+**New features:**
+
+-   `initFormControl` (and also `initFormGroup` and `initFormArray`) now support a third parameter: `disabled`. The parameter is optional and defaults to `false`.
+-   `resetFormControl` resets a `FormControlState` to the original values. Detailed behaviour is described in the documentation. `resetFormGroup` and `resetFormArray` function analogously.
+
+### 4.3.0
 
 **New features:**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,13 @@ id: changelog
 title: Changelog
 ---
 
+## 4.4.0
+
+**New features:**
+
+-   `initFormControl` (and also `initFormGroup` and `initFormArray`) now support a third parameter: `disabled`. The parameter is optional and defaults to `false`.
+-   `resetFormControl` resets a `FormControlState` to the original values. Detailed behaviour is described in the documentation. `resetFormGroup` and `resetFormArray` function analogously.
+
 ## 4.3.0
 
 **New features:**

--- a/docs/control-initialization.md
+++ b/docs/control-initialization.md
@@ -9,10 +9,11 @@ The initialization method supports two different ways of creating a new `FormCon
 
 ## Tuple Initialization
 
-This initialization method is a shorthand and only supports the following two attributes to be set:
+This initialization method is a shorthand and only supports the following three attributes to be set:
 
 -   `value: T`
 -   `validators?: Validator[]`
+-   `disabled?: boolean`
 
 #### Without validators
 
@@ -33,6 +34,14 @@ const below6: Validator<number> = (control: FormControlState<number>) =>
 initFormControl([4, [below6]]);
 ```
 
+#### Initially disabled
+
+```ts
+import { initFormControl, FormControlState } from 'ngrx-clean-forms';
+
+initFormControl(['initial', [], true]);
+```
+
 ## Update Initialization
 
 The update initialization is the more explicit way to initialize a `FormControlState`. This initialization method supports **all** properties that can be set in a `FormControlState`.
@@ -44,17 +53,6 @@ The only required value is the actual value of the `FormControlState`. Other val
 -   `untouched`: `true`
 -   `disabled`: `false`
 -   `validators`: `[]`
-
-#### Initially disabled
-
-```ts
-import { initFormControl } from 'ngrx-clean-forms';
-
-initFormControl({
-    value: 'initial',
-    disabled: true,
-});
-```
 
 #### With validators
 
@@ -68,4 +66,15 @@ initFormControl({
     value: 4,
     validators: [below6]
 }]);
+```
+
+#### Initially disabled
+
+```ts
+import { initFormControl } from 'ngrx-clean-forms';
+
+initFormControl({
+    value: 'initial',
+    disabled: true,
+});
 ```

--- a/docs/control-reset.md
+++ b/docs/control-reset.md
@@ -1,0 +1,26 @@
+---
+id: control-reset
+title: Reset
+---
+
+Resetting a control will change all of its attributes back to the default defined in [initialization](control-initialization#update-initialization). Except for the following attributes, which will stay the same, even after the reset:
+
+-   `initialValue` – can be overridden by passing a new `initialValue`
+-   `validators`
+-   `disabled`
+
+#### Simple reset
+
+```ts
+import { resetFormControl } from 'ngrx-clean-forms';
+
+resetFormControl(control);
+```
+
+#### Reset with new initial value
+
+```ts
+import { resetFormControl } from 'ngrx-clean-forms';
+
+resetFormControl(control, 'newInitial');
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ This framework takes an opinionated approach to managing forms. Following goals 
 
 While all of these goals were met during the implementation of this framework, it comes at the same cost as NgRx. The necessary boilerplate code in comparison to Reactive Forms is significantly larger.
 
-[Example application](example.ngrx-clean-forms.surge.sh).
+[Example application](https://example.ngrx-clean-forms.surge.sh).
 
 ## Installation
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -53,4 +53,4 @@ Switching `'A' -> 'B' -> 'A'` will therefore still set `changed: false`. To rese
 CSS classes:
 
 -   `changed: true` -> `ng-changed`
--   `initial: false` -> `ng-initial`
+-   `changed: false` -> `ng-initial`

--- a/projects/example-app/src/app/+state/example.actions.ts
+++ b/projects/example-app/src/app/+state/example.actions.ts
@@ -13,6 +13,8 @@ export const updateFormGroup = createAction(
     props<{ update: FormGroupUpdate<ExampleGroupControls> }>()
 );
 
+export const resetFormGroup = createAction('[FormGroup] Reset Form Group');
+
 export const updateFormArray = createAction(
     '[FormArray] Update Form Array',
     props<{ update: FormArrayUpdate<string> }>()

--- a/projects/example-app/src/app/+state/example.reducer.ts
+++ b/projects/example-app/src/app/+state/example.reducer.ts
@@ -10,16 +10,11 @@ import {
     reduceFormArray,
     reduceFormControl,
     reduceFormGroup,
+    resetFormGroup,
     Validator,
     validatorOf,
 } from 'ngrx-clean-forms';
-import {
-    addControlToArray,
-    updateFormArray,
-    updateFormGroup,
-    updateSingleFormControl,
-    updateStateAccessExampleFormGroup,
-} from './example.actions';
+import * as ExampleActions from './example.actions';
 
 const below6: Validator<number> = (control: FormControlState<number>) =>
     control.value < 6 ? null : { below6: false };
@@ -51,7 +46,7 @@ export const initialState: ExampleState = {
     singleControl: initFormControl(['initial', [required]]),
     group: initFormGroup({
         textInput: { value: 'disabled', disabled: true },
-        numberInput: [0, [validatorOf(Validators.required, Validators.max(4))]],
+        numberInput: [0, [validatorOf(Validators.required), below6]],
         rangeInput: [0],
         checkboxInput: [false],
         customInput: [0],
@@ -64,22 +59,27 @@ export const initialState: ExampleState = {
 const internalExampleReducer = createReducer(
     initialState,
 
-    on(updateSingleFormControl, (state, { update }) => ({
+    on(ExampleActions.updateSingleFormControl, (state, { update }) => ({
         ...state,
         singleControl: reduceFormControl(state.singleControl, update),
     })),
 
-    on(updateFormGroup, (state, { update }) => ({
+    on(ExampleActions.updateFormGroup, (state, { update }) => ({
         ...state,
         group: reduceFormGroup(state.group, update),
     })),
 
-    on(updateFormArray, (state, { update }) => ({
+    on(ExampleActions.resetFormGroup, state => ({
+        ...state,
+        group: resetFormGroup(state.group),
+    })),
+
+    on(ExampleActions.updateFormArray, (state, { update }) => ({
         ...state,
         array: reduceFormArray(state.array, update),
     })),
 
-    on(addControlToArray, state => ({
+    on(ExampleActions.addControlToArray, state => ({
         ...state,
         array: {
             ...state.array,
@@ -87,7 +87,7 @@ const internalExampleReducer = createReducer(
         },
     })),
 
-    on(updateStateAccessExampleFormGroup, (state, props) => ({
+    on(ExampleActions.updateStateAccessExampleFormGroup, (state, props) => ({
         ...state,
         stateAccessExampleGroup: reduceFormGroup(state.stateAccessExampleGroup, props.update),
     }))

--- a/projects/example-app/src/app/app.component.html
+++ b/projects/example-app/src/app/app.component.html
@@ -13,6 +13,8 @@
                 <input type="checkbox" ngrxFormControl="checkboxInput" />
                 <app-custom-input ngrxFormControl="customInput"></app-custom-input>
             </div>
+
+            <button type="button" (click)="resetFormGroup()">Reset</button>
         </form>
 
         <h3>Single example:</h3>

--- a/projects/example-app/src/app/app.component.ts
+++ b/projects/example-app/src/app/app.component.ts
@@ -27,6 +27,10 @@ export class AppComponent implements OnInit, AfterViewInit {
         this.store.dispatch(ExampleActions.updateSingleFormControl({ update: controlUpdate }));
     }
 
+    resetFormGroup() {
+        this.store.dispatch(ExampleActions.resetFormGroup());
+    }
+
     updateFormGroup(update: FormGroupUpdate<ExampleGroupControls>) {
         this.store.dispatch(ExampleActions.updateFormGroup({ update }));
     }

--- a/projects/ngrx-clean-forms/package.json
+++ b/projects/ngrx-clean-forms/package.json
@@ -23,7 +23,7 @@
         "typescript",
         "redux"
     ],
-    "version": "4.3.0",
+    "version": "4.4.0",
     "peerDependencies": {
         "@angular/common": "^8.2.0",
         "@angular/core": "^8.2.0",

--- a/projects/ngrx-clean-forms/src/lib/init.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/init.spec.ts
@@ -36,6 +36,21 @@ describe('init', () => {
 
                 expect(result).toEqual(expected);
             });
+
+            it('["value", undefined, true] should create a valid form control state which is disabled', () => {
+                const expected: FormControlState<string> = {
+                    value,
+                    initialValue: value,
+                    disabled: true,
+                    pristine: true,
+                    untouched: true,
+                    validators: [],
+                };
+
+                const result = initFormControl([value, undefined, true]);
+
+                expect(result).toEqual(expected);
+            });
         });
 
         describe('initialUpdate', () => {

--- a/projects/ngrx-clean-forms/src/lib/init.ts
+++ b/projects/ngrx-clean-forms/src/lib/init.ts
@@ -68,11 +68,12 @@ export function initFormArray<T>(initial: FormArrayInit<T>): FormArrayState<T> {
     };
 }
 
-function initFormControlFromTuple<T>([value, validators]: FormControlInitTuple<
-    T
->): FormControlState<T> {
-    validators = validators || [];
-    return initFormControlFromUpdate({ value, validators });
+function initFormControlFromTuple<T>([
+    value,
+    validators = [],
+    disabled = false,
+]: FormControlInitTuple<T>): FormControlState<T> {
+    return initFormControlFromUpdate({ value, validators, disabled });
 }
 
 function initFormControlFromUpdate<T = any>(

--- a/projects/ngrx-clean-forms/src/lib/reset.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.spec.ts
@@ -5,9 +5,10 @@ import { initFormControl, initFormGroup, initFormArray } from './init';
 describe('resetFormControl', () => {
     const initialValue = 'initial';
     const validators = [() => null];
+    const disabled = true;
 
     const control: FormControlState<string> = {
-        disabled: true,
+        disabled,
         initialValue,
         pristine: false,
         untouched: false,
@@ -21,11 +22,18 @@ describe('resetFormControl', () => {
         expect(result.validators).toBe(validators);
     });
 
+    it('should keep disabled', () => {
+        const result = resetFormControl(control);
+
+        expect(result.disabled).toBe(disabled);
+    });
+
     it('should reset everything except validators to initial', () => {
         const result = resetFormControl(control);
         const expected = initFormControl([initialValue]);
 
         expected.validators = validators;
+        expected.disabled = disabled;
 
         expect(result).toEqual(expected);
     });
@@ -71,8 +79,8 @@ describe('resetFormGorup', () => {
     it('should reset group', () => {
         const result = resetFormGroup(group);
         const expected: typeof group = initFormGroup({
-            k1: [initialValue1, validators1],
-            k2: [initialValue2, validators2],
+            k1: [initialValue1, validators1, true],
+            k2: [initialValue2, validators2, false],
         });
 
         expect(result).toEqual(expected);
@@ -110,8 +118,8 @@ describe('resetFormArray', () => {
     it('should reset group', () => {
         const result = resetFormArray(array);
         const expected: typeof array = initFormArray([
-            [initialValue1, validators1],
-            [initialValue2, validators2],
+            [initialValue1, validators1, true],
+            [initialValue2, validators2, false],
         ]);
 
         expect(result).toEqual(expected);

--- a/projects/ngrx-clean-forms/src/lib/reset.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.spec.ts
@@ -1,0 +1,41 @@
+import { FormControlState } from './types';
+import { resetFormControl } from './reset';
+import { initFormControl } from './init';
+
+describe('resetFormControl', () => {
+    const initialValue = 'initial';
+    const validators = [() => null];
+
+    const control: FormControlState<string> = {
+        disabled: true,
+        initialValue,
+        pristine: false,
+        untouched: false,
+        validators,
+        value: 'value',
+    };
+
+    it('should keep validators', () => {
+        const result = resetFormControl(control);
+
+        expect(result.validators).toBe(validators);
+    });
+
+    it('should reset everything except validators to initial', () => {
+        const result = resetFormControl(control);
+        const expected = initFormControl([initialValue]);
+
+        expected.validators = validators;
+
+        expect(result).toEqual(expected);
+    });
+
+    it('should set initialValue and value if passed', () => {
+        const newValue = 'newValue';
+
+        const result = resetFormControl(control, newValue);
+
+        expect(result.value).toEqual(newValue);
+        expect(result.initialValue).toEqual(newValue);
+    });
+});

--- a/projects/ngrx-clean-forms/src/lib/reset.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.spec.ts
@@ -1,6 +1,6 @@
-import { FormControlState, FormGroupState } from './types';
-import { resetFormControl, resetFormGroup } from './reset';
-import { initFormControl, initFormGroup } from './init';
+import { FormControlState, FormGroupState, FormArrayState } from './types';
+import { resetFormControl, resetFormGroup, resetFormArray } from './reset';
+import { initFormControl, initFormGroup, initFormArray } from './init';
 
 describe('resetFormControl', () => {
     const initialValue = 'initial';
@@ -74,6 +74,45 @@ describe('resetFormGorup', () => {
             k1: [initialValue1, validators1],
             k2: [initialValue2, validators2],
         });
+
+        expect(result).toEqual(expected);
+    });
+});
+
+describe('resetFormArray', () => {
+    const initialValue1 = 'init1';
+    const initialValue2 = 'init2';
+
+    const validators1 = [() => ({ alwaysTrue: true })];
+    const validators2 = [];
+
+    const array: FormArrayState<string> = {
+        controls: [
+            {
+                disabled: true,
+                initialValue: initialValue1,
+                value: 'some1',
+                pristine: false,
+                untouched: true,
+                validators: validators1,
+            },
+            {
+                disabled: false,
+                initialValue: initialValue2,
+                value: 'some2',
+                pristine: false,
+                untouched: true,
+                validators: validators2,
+            },
+        ],
+    };
+
+    it('should reset group', () => {
+        const result = resetFormArray(array);
+        const expected: typeof array = initFormArray([
+            [initialValue1, validators1],
+            [initialValue2, validators2],
+        ]);
 
         expect(result).toEqual(expected);
     });

--- a/projects/ngrx-clean-forms/src/lib/reset.spec.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.spec.ts
@@ -1,6 +1,6 @@
-import { FormControlState } from './types';
-import { resetFormControl } from './reset';
-import { initFormControl } from './init';
+import { FormControlState, FormGroupState } from './types';
+import { resetFormControl, resetFormGroup } from './reset';
+import { initFormControl, initFormGroup } from './init';
 
 describe('resetFormControl', () => {
     const initialValue = 'initial';
@@ -37,5 +37,44 @@ describe('resetFormControl', () => {
 
         expect(result.value).toEqual(newValue);
         expect(result.initialValue).toEqual(newValue);
+    });
+});
+
+describe('resetFormGorup', () => {
+    const initialValue1 = 'init1';
+    const initialValue2 = 'init2';
+
+    const validators1 = [() => ({ alwaysTrue: true })];
+    const validators2 = [];
+
+    const group: FormGroupState<{ k1: string; k2: string }> = {
+        controls: {
+            k1: {
+                disabled: true,
+                initialValue: initialValue1,
+                value: 'some1',
+                pristine: false,
+                untouched: true,
+                validators: validators1,
+            },
+            k2: {
+                disabled: false,
+                initialValue: initialValue2,
+                value: 'some2',
+                pristine: false,
+                untouched: true,
+                validators: validators2,
+            },
+        },
+    };
+
+    it('should reset group', () => {
+        const result = resetFormGroup(group);
+        const expected: typeof group = initFormGroup({
+            k1: [initialValue1, validators1],
+            k2: [initialValue2, validators2],
+        });
+
+        expect(result).toEqual(expected);
     });
 });

--- a/projects/ngrx-clean-forms/src/lib/reset.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.ts
@@ -1,9 +1,21 @@
-import { FormControlState } from './types';
-import { initFormControl } from './init';
+import { FormControlState, FormControls, FormGroupState, FormControlInitTuple } from './types';
+import { initFormControl, initFormGroup } from './init';
+import { mapFormGroupControlStates } from './utils';
 
 export function resetFormControl<T>(
     control: FormControlState<T>,
     initialValue = control.initialValue
-) {
+): FormControlState<T> {
     return initFormControl([initialValue, control.validators]);
+}
+
+export function resetFormGroup<TControls extends FormControls>(
+    group: FormGroupState<TControls>
+): FormGroupState<TControls> {
+    const initTuple = mapFormGroupControlStates(
+        group.controls,
+        ({ initialValue, validators }): FormControlInitTuple<any> => [initialValue, validators]
+    );
+
+    return initFormGroup(initTuple);
 }

--- a/projects/ngrx-clean-forms/src/lib/reset.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.ts
@@ -1,18 +1,14 @@
-import {
-    FormControlState,
-    FormControls,
-    FormGroupState,
-    FormControlInitTuple,
-    FormArrayState,
-} from './types';
-import { initFormControl, initFormGroup, initFormArray } from './init';
+import { initFormControl } from './init';
+import { reduceFormArray, reduceFormGroup } from './reducer';
+import { FormArrayState, FormControls, FormControlState, FormGroupState } from './types';
 import { mapFormGroupControlStates } from './utils';
 
 /**
  * Resets a control back to the default values.
- * The following values will stay the same after the reset:
+ * The following values will be ignored and stay the same:
  * - `initialValue`
  * - `validators`
+ * - `disabled`
  *
  * @param control The `FormControlState` which should be used to create the reset.
  * @param initialValue Optional parameter for passing a new initial value.
@@ -21,7 +17,7 @@ export function resetFormControl<T>(
     control: FormControlState<T>,
     initialValue = control.initialValue
 ): FormControlState<T> {
-    return initFormControl([initialValue, control.validators]);
+    return initFormControl([initialValue, control.validators, control.disabled]);
 }
 
 /**
@@ -35,12 +31,11 @@ export function resetFormControl<T>(
 export function resetFormGroup<TControls extends FormControls>(
     group: FormGroupState<TControls>
 ): FormGroupState<TControls> {
-    const initTuple = mapFormGroupControlStates(
-        group.controls,
-        ({ initialValue, validators }): FormControlInitTuple<any> => [initialValue, validators]
+    const controls = mapFormGroupControlStates(group.controls, control =>
+        resetFormControl(control)
     );
 
-    return initFormGroup(initTuple);
+    return reduceFormGroup(group, { controls });
 }
 
 /**
@@ -52,9 +47,7 @@ export function resetFormGroup<TControls extends FormControls>(
  * @param array The `FormArrayState` which should be used to create the reset.
  */
 export function resetFormArray<T>(array: FormArrayState<T>): FormArrayState<T> {
-    const initTuple = array.controls.map(
-        ({ initialValue, validators }): FormControlInitTuple<any> => [initialValue, validators]
-    );
+    const controls = array.controls.map(control => resetFormControl(control));
 
-    return initFormArray(initTuple);
+    return reduceFormArray(array, { controls });
 }

--- a/projects/ngrx-clean-forms/src/lib/reset.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.ts
@@ -1,0 +1,9 @@
+import { FormControlState } from './types';
+import { initFormControl } from './init';
+
+export function resetFormControl<T>(
+    control: FormControlState<T>,
+    initialValue = control.initialValue
+) {
+    return initFormControl([initialValue, control.validators]);
+}

--- a/projects/ngrx-clean-forms/src/lib/reset.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.ts
@@ -1,5 +1,11 @@
-import { FormControlState, FormControls, FormGroupState, FormControlInitTuple } from './types';
-import { initFormControl, initFormGroup } from './init';
+import {
+    FormControlState,
+    FormControls,
+    FormGroupState,
+    FormControlInitTuple,
+    FormArrayState,
+} from './types';
+import { initFormControl, initFormGroup, initFormArray } from './init';
 import { mapFormGroupControlStates } from './utils';
 
 export function resetFormControl<T>(
@@ -18,4 +24,12 @@ export function resetFormGroup<TControls extends FormControls>(
     );
 
     return initFormGroup(initTuple);
+}
+
+export function resetFormArray<T>(array: FormArrayState<T>): FormArrayState<T> {
+    const initTuple = array.controls.map(
+        ({ initialValue, validators }): FormControlInitTuple<any> => [initialValue, validators]
+    );
+
+    return initFormArray(initTuple);
 }

--- a/projects/ngrx-clean-forms/src/lib/reset.ts
+++ b/projects/ngrx-clean-forms/src/lib/reset.ts
@@ -8,6 +8,15 @@ import {
 import { initFormControl, initFormGroup, initFormArray } from './init';
 import { mapFormGroupControlStates } from './utils';
 
+/**
+ * Resets a control back to the default values.
+ * The following values will stay the same after the reset:
+ * - `initialValue`
+ * - `validators`
+ *
+ * @param control The `FormControlState` which should be used to create the reset.
+ * @param initialValue Optional parameter for passing a new initial value.
+ */
 export function resetFormControl<T>(
     control: FormControlState<T>,
     initialValue = control.initialValue
@@ -15,6 +24,14 @@ export function resetFormControl<T>(
     return initFormControl([initialValue, control.validators]);
 }
 
+/**
+ * Resets a group back to its default values.
+ * Internally calls `resetFormControl` for every control.
+ *
+ * @see `resetFormControl`
+ *
+ * @param group The `FormGroupState` which should be used to create the reset.
+ */
 export function resetFormGroup<TControls extends FormControls>(
     group: FormGroupState<TControls>
 ): FormGroupState<TControls> {
@@ -26,6 +43,14 @@ export function resetFormGroup<TControls extends FormControls>(
     return initFormGroup(initTuple);
 }
 
+/**
+ * Resets an array back to its default values.
+ * Internally calls `resetFormControl` for every control.
+ *
+ * @see `resetFormControl`
+ *
+ * @param array The `FormArrayState` which should be used to create the reset.
+ */
 export function resetFormArray<T>(array: FormArrayState<T>): FormArrayState<T> {
     const initTuple = array.controls.map(
         ({ initialValue, validators }): FormControlInitTuple<any> => [initialValue, validators]

--- a/projects/ngrx-clean-forms/src/lib/types.ts
+++ b/projects/ngrx-clean-forms/src/lib/types.ts
@@ -66,8 +66,9 @@ export type FormControlInit<T> = FormControlInitTuple<T> | FormControlInitUpdate
  * A shorthand to create a new FormControl.
  * - [0]: Initial value of the control.
  * - [1]: Validator array. Optional.
+ * - [2]: Disabled state. Default false. Optional.
  */
-export type FormControlInitTuple<T> = [T, Validator<T>[]?];
+export type FormControlInitTuple<T> = [T, Validator<T>[]?, boolean?];
 
 /**
  * An object of keys and associated `FormControlInit`.

--- a/projects/ngrx-clean-forms/src/public-api.ts
+++ b/projects/ngrx-clean-forms/src/public-api.ts
@@ -1,4 +1,5 @@
 export { initFormControl, initFormGroup, initFormArray } from './lib/init';
+export { resetFormControl, resetFormGroup, resetFormArray } from './lib/reset';
 export { reduceFormControl, reduceFormGroup, reduceFormArray } from './lib/reducer';
 export { getFormControlSummary, getFormGroupSummary, getFormArraySummary } from './lib/selectors';
 export * from './lib/types';

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -11,6 +11,9 @@
       "control-initialization": {
         "title": "Initialization"
       },
+      "control-reset": {
+        "title": "Reset"
+      },
       "empty": {
         "title": "empty"
       },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,7 @@
 {
     "docs": {
         "Introduction": ["getting-started", "first-form"],
-        "FormControl": ["control-initialization", "form-validation", "status"],
+        "FormControl": ["control-initialization", "form-validation", "status", "control-reset"],
         "FormGroup": [],
         "FormArray": [],
         "Other": ["changelog", "not-supported"]


### PR DESCRIPTION

-   `initFormControl` (and also `initFormGroup` and `initFormArray`) now support a third parameter: `disabled`. The parameter is optional and defaults to `false`.
-   `resetFormControl` resets a `FormControlState` to the original values. Detailed behaviour is described in the documentation. `resetFormGroup` and `resetFormArray` function analogously.
