### PR TITLE
[Feature] Expose control summary via Subject

### DIFF
--- a/projects/ngrx-clean-forms/src/lib/directives/controls/abstract-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/abstract-control.directive.ts
@@ -28,7 +28,7 @@ const cssClasses = {
 export const CONTROL_DIRECTIVE_SELECTOR = `ngrxFormControl`;
 
 @Directive()
-export abstract class AbstractControlDirective<T> implements OnDestroy {
+export abstract class AbstractControlDirective<T = any> implements OnDestroy {
     @Input(CONTROL_DIRECTIVE_SELECTOR)
     controlKey?: string;
 
@@ -52,6 +52,13 @@ export abstract class AbstractControlDirective<T> implements OnDestroy {
     }
 
     @Output() controlUpdate = new EventEmitter<FormControlUpdate<T>>(true);
+    controlSummary$ = new Subject<FormControlSummary<T>>();
+
+    get controlSummary() {
+        return this._controlSummary;
+    }
+
+    private _controlSummary: FormControlSummary<T>;
 
     constructor(
         protected ref: ElementRef,
@@ -95,6 +102,8 @@ export abstract class AbstractControlDirective<T> implements OnDestroy {
     }
 
     updateSummary(summary: FormControlSummary<T>) {
+        this._controlSummary = summary;
+        this.controlSummary$.next(summary);
         if (this.isValueChanged(summary.value)) {
             this.setValue(summary.value);
         }
@@ -122,5 +131,6 @@ export abstract class AbstractControlDirective<T> implements OnDestroy {
         this.config$.complete();
         this.touched$.complete();
         this.value$.complete();
+        this.controlSummary$.complete();
     }
 }

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/abstract-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/abstract-control.directive.ts
@@ -52,11 +52,13 @@ export abstract class AbstractControlDirective<T = any> implements OnDestroy {
     }
 
     @Output() controlUpdate = new EventEmitter<FormControlUpdate<T>>(true);
-    controlSummary$ = new Subject<FormControlSummary<T>>();
 
     get controlSummary() {
         return this._controlSummary;
     }
+
+    private _controlSummary$ = new Subject<FormControlSummary<T>>();
+    readonly controlSummary$ = this._controlSummary$.asObservable();
 
     private _controlSummary: FormControlSummary<T>;
 
@@ -103,7 +105,7 @@ export abstract class AbstractControlDirective<T = any> implements OnDestroy {
 
     updateSummary(summary: FormControlSummary<T>) {
         this._controlSummary = summary;
-        this.controlSummary$.next(summary);
+        this._controlSummary$.next(summary);
         if (this.isValueChanged(summary.value)) {
             this.setValue(summary.value);
         }
@@ -131,6 +133,6 @@ export abstract class AbstractControlDirective<T = any> implements OnDestroy {
         this.config$.complete();
         this.touched$.complete();
         this.value$.complete();
-        this.controlSummary$.complete();
+        this._controlSummary$.complete();
     }
 }

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/checkbox-input-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/checkbox-input-control.directive.ts
@@ -5,6 +5,12 @@ import { FormsConfig } from '../../types';
 
 @Directive({
     selector: `input[type="checkbox"][${CONTROL_DIRECTIVE_SELECTOR}]`,
+    providers: [
+        {
+            provide: AbstractControlDirective,
+            useExisting: CheckboxInputControlDirective,
+        },
+    ],
 })
 export class CheckboxInputControlDirective extends AbstractControlDirective<boolean> {
     constructor(ref: ElementRef, r2: Renderer2, @Inject(CONFIG_TOKEN) config: FormsConfig) {

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/number-input-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/number-input-control.directive.ts
@@ -4,6 +4,12 @@ import { FormsConfig } from '../../types';
 import { CONFIG_TOKEN } from '../../config';
 @Directive({
     selector: `input[type="number"][${CONTROL_DIRECTIVE_SELECTOR}]`,
+    providers: [
+        {
+            provide: AbstractControlDirective,
+            useExisting: NumberInputControlDirective,
+        },
+    ],
 })
 export class NumberInputControlDirective extends AbstractControlDirective<number> {
     constructor(ref: ElementRef, r2: Renderer2, @Inject(CONFIG_TOKEN) config: FormsConfig) {

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/radio-input-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/radio-input-control.directive.ts
@@ -10,6 +10,12 @@ export const RadioControlNotSupported = Error(
 
 @Directive({
     selector: `input[type="radio"][${CONTROL_DIRECTIVE_SELECTOR}]`,
+    providers: [
+        {
+            provide: AbstractControlDirective,
+            useExisting: RadioInputControlDirective,
+        },
+    ],
 })
 export class RadioInputControlDirective extends AbstractControlDirective<boolean> {
     constructor(ref: ElementRef, r2: Renderer2, @Inject(CONFIG_TOKEN) config: FormsConfig) {

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/range-input-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/range-input-control.directive.ts
@@ -4,6 +4,12 @@ import { CONFIG_TOKEN } from '../../config';
 import { FormsConfig } from '../../types';
 @Directive({
     selector: `input[type="range"][${CONTROL_DIRECTIVE_SELECTOR}]`,
+    providers: [
+        {
+            provide: AbstractControlDirective,
+            useExisting: RangeInputControlDirective,
+        },
+    ],
 })
 export class RangeInputControlDirective extends AbstractControlDirective<number> {
     constructor(ref: ElementRef, r2: Renderer2, @Inject(CONFIG_TOKEN) config: FormsConfig) {

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/select-input-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/select-input-control.directive.ts
@@ -10,6 +10,12 @@ export const SelectControlNotSupported = Error(
 
 @Directive({
     selector: `select[${CONTROL_DIRECTIVE_SELECTOR}]`,
+    providers: [
+        {
+            provide: AbstractControlDirective,
+            useExisting: SelectInputControlDirective,
+        },
+    ],
 })
 export class SelectInputControlDirective extends AbstractControlDirective<boolean> {
     constructor(ref: ElementRef, r2: Renderer2, @Inject(CONFIG_TOKEN) config: FormsConfig) {

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/text-input-control.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/text-input-control.directive.ts
@@ -6,6 +6,12 @@ import { FormsConfig } from '../../types';
 @Directive({
     // tslint:disable-next-line: max-line-length
     selector: `input[type="text"][${CONTROL_DIRECTIVE_SELECTOR}],textarea[${CONTROL_DIRECTIVE_SELECTOR}],input:not([type="checkbox"]):not([type="number"]):not([type="range"]):not([type="radio"])[${CONTROL_DIRECTIVE_SELECTOR}]`,
+    providers: [
+        {
+            provide: AbstractControlDirective,
+            useExisting: TextInputControlDirective,
+        },
+    ],
 })
 export class TextInputControlDirective extends AbstractControlDirective<string> {
     constructor(ref: ElementRef, r2: Renderer2, @Inject(CONFIG_TOKEN) config: FormsConfig) {

--- a/projects/ngrx-clean-forms/src/lib/directives/controls/value-accessor-connector.directive.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/controls/value-accessor-connector.directive.ts
@@ -3,10 +3,15 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { CONFIG_TOKEN } from '../../config';
 import { FormsConfig } from '../../types';
 import { AbstractControlDirective, CONTROL_DIRECTIVE_SELECTOR } from './abstract-control.directive';
-import { circularDeepEqual } from 'fast-equals';
 
 @Directive({
-    selector: `[${CONTROL_DIRECTIVE_SELECTOR}]`,
+    selector: `[${CONTROL_DIRECTIVE_SELECTOR}]:not(input):not(textarea):not(select)`,
+    providers: [
+        {
+            provide: AbstractControlDirective,
+            useExisting: ValueAccessorConnectorDirective,
+        },
+    ],
 })
 export class ValueAccessorConnectorDirective extends AbstractControlDirective<any> {
     accessor: ControlValueAccessor;

--- a/projects/ngrx-clean-forms/src/lib/directives/group/control-children.ts
+++ b/projects/ngrx-clean-forms/src/lib/directives/group/control-children.ts
@@ -1,57 +1,15 @@
 import { ContentChildren, QueryList, Directive } from '@angular/core';
 import { AbstractControlDirective } from '../controls/abstract-control.directive';
-import { NumberInputControlDirective } from './../controls/number-input-control.directive';
-import { TextInputControlDirective } from './../controls/text-input-control.directive';
-import { ValueAccessorConnectorDirective } from '../controls/value-accessor-connector.directive';
-import { CheckboxInputControlDirective } from '../controls/checkbox-input-control.directive';
-import { RangeInputControlDirective } from '../controls/range-input-control.directive';
-import { RadioInputControlDirective } from '../controls/radio-input-control.directive';
-import { SelectInputControlDirective } from '../controls/select-input-control.directive';
 import { map, startWith } from 'rxjs/operators';
-import { combineLatest } from 'rxjs';
 
-type directiveQuery = QueryList<AbstractControlDirective<any>>;
+type directiveQuery = QueryList<AbstractControlDirective>;
 @Directive()
 export abstract class ControlChildrenDirective {
-    @ContentChildren(TextInputControlDirective, { descendants: true })
-    private textInputs: directiveQuery;
-
-    @ContentChildren(CheckboxInputControlDirective, { descendants: true })
-    private checkboxInputs: directiveQuery;
-
-    @ContentChildren(NumberInputControlDirective, { descendants: true })
-    private numberInputs: directiveQuery;
-
-    @ContentChildren(RadioInputControlDirective, { descendants: true })
-    private radioInputs: directiveQuery;
-
-    @ContentChildren(RangeInputControlDirective, { descendants: true })
-    private rangeInputs: directiveQuery;
-
-    @ContentChildren(SelectInputControlDirective, { descendants: true })
-    private selectInputs: directiveQuery;
-
-    @ContentChildren(ValueAccessorConnectorDirective, { descendants: true })
-    private customInputs: directiveQuery;
+    @ContentChildren(AbstractControlDirective, { descendants: true })
+    private abstractInputs: directiveQuery;
 
     protected getChildren() {
-        const queries$ = [
-            this.textInputs,
-            this.numberInputs,
-            this.radioInputs,
-            this.rangeInputs,
-            this.selectInputs,
-            this.customInputs,
-            this.checkboxInputs,
-        ]
-            .filter(Boolean)
-            .map((query) => {
-                return this.convertToObservable(query);
-            });
-
-        return combineLatest(queries$).pipe(
-            map((queries) => queries.reduce((q1, q2) => [...q1, ...q2], []))
-        );
+        return this.convertToObservable(this.abstractInputs);
     }
 
     private convertToObservable(query: directiveQuery) {


### PR DESCRIPTION
Hey, nice work with the reactive forms. I want to use it in wrapper classes and it would be a dream to have the controlSummary available in parent components.

For this i introduced a new Subject in the AbstractControlDirective
```typescript
    controlSummary$ = new Subject<FormControlSummary<T>>();
```

Furthermore i updated the Dependency Injection slightly by exposing the Implementations via a unified Token (`AbstractControlDirective`).

```typescript
@Directive({
    selector: `input[type="checkbox"][${CONTROL_DIRECTIVE_SELECTOR}]`,
    providers: [
        {
            provide: AbstractControlDirective,
            useExisting: CheckboxInputControlDirective,
        },
    ],
})
```
